### PR TITLE
Fix typo in GetUser method

### DIFF
--- a/client.go
+++ b/client.go
@@ -572,7 +572,7 @@ func (client *gocloak) GetKeyStoreConfig(token string, realm string) (*KeyStoreC
 // GetUser get all users inr ealm
 func (client *gocloak) GetUser(token string, realm string, userID string) (*User, error) {
 	resp, err := getRequestWithHeader(token).
-		Get(client.basePath + authRealm + realm + "/user/" + userID)
+		Get(client.basePath + authRealm + realm + "/users/" + userID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This typo doesn't allow to get user representation according to
keycloak REST API documentation. Right path should be `users`
instead of just `user`
(https://www.keycloak.org/docs-api/4.8/rest-api/index.html#_users_resource,
section "Get representation of the user").