### PR TITLE
Refactoring of usage of resty Request's object

### DIFF
--- a/client.go
+++ b/client.go
@@ -326,7 +326,6 @@ func (client *gocloak) SetPassword(token string, userID string, realm string, pa
 		return err
 	}
 	resp, err := getRequestWithHeader(token).
-		SetHeader("Content-Type", "application/json").
 		SetBody(string(bytes)).
 		Put(client.basePath + authRealm + realm + "/users/" + userID + "/reset-password")
 
@@ -348,7 +347,6 @@ func (client *gocloak) CreateUser(token string, realm string, user User) (*strin
 		return nil, err
 	}
 	resp, err := getRequestWithHeader(token).
-		SetHeader("Content-Type", "application/json").
 		SetBody(string(bytes)).
 		Post(client.basePath + authRealm + realm + "/users")
 
@@ -374,7 +372,6 @@ func (client *gocloak) CreateGroup(token string, realm string, group Group) erro
 		return err
 	}
 	resp, err := getRequestWithHeader(token).
-		SetHeader("Content-Type", "application/json").
 		SetBody(string(bytes)).
 		Post(client.basePath + authRealm + realm + "/groups")
 
@@ -396,7 +393,6 @@ func (client *gocloak) CreateComponent(token string, realm string, component Com
 		return err
 	}
 	resp, err := getRequestWithHeader(token).
-		SetHeader("Content-Type", "application/json").
 		SetBody(string(bytes)).
 		Post(client.basePath + authRealm + realm + "/components")
 
@@ -418,7 +414,6 @@ func (client *gocloak) CreateClient(token string, realm string, newClient Client
 		return err
 	}
 	resp, err := getRequestWithHeader(token).
-		SetHeader("Content-Type", "application/json").
 		SetBody(string(bytes)).
 		Post(client.basePath + authRealm + realm + "/clients")
 
@@ -440,7 +435,6 @@ func (client *gocloak) CreateRole(token string, realm string, clientID string, r
 		return err
 	}
 	resp, err := getRequestWithHeader(token).
-		SetHeader("Content-Type", "application/json").
 		SetBody(string(bytes)).
 		Post(client.basePath + authRealm + realm + "clients/" + clientID + "/roles")
 
@@ -462,7 +456,6 @@ func (client *gocloak) CreateClientScope(token string, realm string, scope Clien
 		return err
 	}
 	resp, err := getRequestWithHeader(token).
-		SetHeader("Content-Type", "application/json").
 		SetBody(string(bytes)).
 		Post(client.basePath + authRealm + realm + "/client-scopes")
 
@@ -484,7 +477,6 @@ func (client *gocloak) UpdateUser(token string, realm string, user User) error {
 		return err
 	}
 	resp, err := getRequestWithHeader(token).
-		SetHeader("Content-Type", "application/json").
 		SetBody(string(bytes)).
 		Put(client.basePath + authRealm + realm + "/users/" + user.ID)
 
@@ -506,7 +498,6 @@ func (client *gocloak) UpdateGroup(token string, realm string, group Group) erro
 		return err
 	}
 	resp, err := getRequestWithHeader(token).
-		SetHeader("Content-Type", "application/json").
 		SetBody(string(bytes)).
 		Put(client.basePath + authRealm + realm + "/groups/" + group.ID)
 
@@ -528,7 +519,6 @@ func (client *gocloak) UpdateClient(token string, realm string, newClient Client
 		return err
 	}
 	resp, err := getRequestWithHeader(token).
-		SetHeader("Content-Type", "application/json").
 		SetBody(string(bytes)).
 		Put(client.basePath + authRealm + realm + "/clients")
 
@@ -550,7 +540,6 @@ func (client *gocloak) UpdateRole(token string, realm string, clientID string, r
 		return err
 	}
 	resp, err := getRequestWithHeader(token).
-		SetHeader("Content-Type", "application/json").
 		SetBody(string(bytes)).
 		Put(client.basePath + authRealm + realm + "/clients/" + clientID + "/roles/" + role.Name)
 
@@ -572,7 +561,6 @@ func (client *gocloak) UpdateClientScope(token string, realm string, scope Clien
 		return err
 	}
 	resp, err := getRequestWithHeader(token).
-		SetHeader("Content-Type", "application/json").
 		SetBody(string(bytes)).
 		Put(client.basePath + authRealm + realm + "/client-scopes/" + scope.ID)
 
@@ -590,7 +578,6 @@ func (client *gocloak) UpdateClientScope(token string, realm string, scope Clien
 // DeleteUser creates a new user
 func (client *gocloak) DeleteUser(token string, realm string, userID string) error {
 	resp, err := getRequestWithHeader(token).
-		SetHeader("Content-Type", "application/json").
 		Delete(client.basePath + authRealm + realm + "/users/" + userID)
 
 	if err != nil {
@@ -607,7 +594,6 @@ func (client *gocloak) DeleteUser(token string, realm string, userID string) err
 // DeleteUser creates a new user
 func (client *gocloak) DeleteGroup(token string, realm string, groupID string) error {
 	resp, err := getRequestWithHeader(token).
-		SetHeader("Content-Type", "application/json").
 		Delete(client.basePath + authRealm + realm + "/groups/" + groupID)
 
 	if err != nil {
@@ -624,7 +610,6 @@ func (client *gocloak) DeleteGroup(token string, realm string, groupID string) e
 // DeleteUser creates a new user
 func (client *gocloak) DeleteClient(token string, realm string, clientID string) error {
 	resp, err := getRequestWithHeader(token).
-		SetHeader("Content-Type", "application/json").
 		Delete(client.basePath + authRealm + realm + "/clients/" + clientID)
 
 	if err != nil {
@@ -641,7 +626,6 @@ func (client *gocloak) DeleteClient(token string, realm string, clientID string)
 // DeleteComponent creates a new user
 func (client *gocloak) DeleteComponent(token string, realm string, componentID string) error {
 	resp, err := getRequestWithHeader(token).
-		SetHeader("Content-Type", "application/json").
 		Delete(client.basePath + authRealm + realm + "/components/" + componentID)
 
 	if err != nil {
@@ -658,7 +642,6 @@ func (client *gocloak) DeleteComponent(token string, realm string, componentID s
 // DeleteUser creates a new user
 func (client *gocloak) DeleteRole(token string, realm string, clientID, roleName string) error {
 	resp, err := getRequestWithHeader(token).
-		SetHeader("Content-Type", "application/json").
 		Delete(client.basePath + authRealm + realm + "/clients/" + clientID + "/roles/" + roleName)
 
 	if err != nil {
@@ -675,7 +658,6 @@ func (client *gocloak) DeleteRole(token string, realm string, clientID, roleName
 // DeleteClientScope creates a new client scope
 func (client *gocloak) DeleteClientScope(token string, realm string, scopeID string) error {
 	resp, err := getRequestWithHeader(token).
-		SetHeader("Content-Type", "application/json").
 		Put(client.basePath + authRealm + realm + "/client-scopes/" + scopeID)
 
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -315,12 +315,8 @@ func (client *gocloak) RequestPermission(clientID string, clientSecret string, r
 // SetPassword sets a new password
 func (client *gocloak) SetPassword(token string, userID string, realm string, password string, temporary bool) error {
 	requestBody := SetPasswordRequest{Password: password, Temporary: temporary, Type: "password"}
-	bytes, err := json.Marshal(requestBody)
-	if err != nil {
-		return err
-	}
 	resp, err := getRequestWithBearerAuth(token).
-		SetBody(string(bytes)).
+		SetBody(requestBody).
 		Put(client.basePath + authRealm + realm + "/users/" + userID + "/reset-password")
 
 	if err != nil {
@@ -336,12 +332,8 @@ func (client *gocloak) SetPassword(token string, userID string, realm string, pa
 
 // CreateUser tries to create the given user in the given realm and returns it's userID
 func (client *gocloak) CreateUser(token string, realm string, user User) (*string, error) {
-	bytes, err := json.Marshal(user)
-	if err != nil {
-		return nil, err
-	}
 	resp, err := getRequestWithBearerAuth(token).
-		SetBody(string(bytes)).
+		SetBody(user).
 		Post(client.basePath + authRealm + realm + "/users")
 
 	if err != nil {
@@ -361,12 +353,8 @@ func (client *gocloak) CreateUser(token string, realm string, user User) (*strin
 
 // CreateUser creates a new user
 func (client *gocloak) CreateGroup(token string, realm string, group Group) error {
-	bytes, err := json.Marshal(group)
-	if err != nil {
-		return err
-	}
 	resp, err := getRequestWithBearerAuth(token).
-		SetBody(string(bytes)).
+		SetBody(group).
 		Post(client.basePath + authRealm + realm + "/groups")
 
 	if err != nil {
@@ -382,12 +370,8 @@ func (client *gocloak) CreateGroup(token string, realm string, group Group) erro
 
 // CreateComponent creates a new user
 func (client *gocloak) CreateComponent(token string, realm string, component Component) error {
-	bytes, err := json.Marshal(component)
-	if err != nil {
-		return err
-	}
 	resp, err := getRequestWithBearerAuth(token).
-		SetBody(string(bytes)).
+		SetBody(component).
 		Post(client.basePath + authRealm + realm + "/components")
 
 	if err != nil {
@@ -403,12 +387,8 @@ func (client *gocloak) CreateComponent(token string, realm string, component Com
 
 // CreateUser creates a new user
 func (client *gocloak) CreateClient(token string, realm string, newClient Client) error {
-	bytes, err := json.Marshal(newClient)
-	if err != nil {
-		return err
-	}
 	resp, err := getRequestWithBearerAuth(token).
-		SetBody(string(bytes)).
+		SetBody(newClient).
 		Post(client.basePath + authRealm + realm + "/clients")
 
 	if err != nil {
@@ -424,12 +404,8 @@ func (client *gocloak) CreateClient(token string, realm string, newClient Client
 
 // CreateUser creates a new user
 func (client *gocloak) CreateRole(token string, realm string, clientID string, role Role) error {
-	bytes, err := json.Marshal(role)
-	if err != nil {
-		return err
-	}
 	resp, err := getRequestWithBearerAuth(token).
-		SetBody(string(bytes)).
+		SetBody(role).
 		Post(client.basePath + authRealm + realm + "clients/" + clientID + "/roles")
 
 	if err != nil {
@@ -445,12 +421,8 @@ func (client *gocloak) CreateRole(token string, realm string, clientID string, r
 
 // CreateClientScope creates a new client scope
 func (client *gocloak) CreateClientScope(token string, realm string, scope ClientScope) error {
-	bytes, err := json.Marshal(scope)
-	if err != nil {
-		return err
-	}
 	resp, err := getRequestWithBearerAuth(token).
-		SetBody(string(bytes)).
+		SetBody(scope).
 		Post(client.basePath + authRealm + realm + "/client-scopes")
 
 	if err != nil {
@@ -466,12 +438,8 @@ func (client *gocloak) CreateClientScope(token string, realm string, scope Clien
 
 // UpdateUser creates a new user
 func (client *gocloak) UpdateUser(token string, realm string, user User) error {
-	bytes, err := json.Marshal(user)
-	if err != nil {
-		return err
-	}
 	resp, err := getRequestWithBearerAuth(token).
-		SetBody(string(bytes)).
+		SetBody(user).
 		Put(client.basePath + authRealm + realm + "/users/" + user.ID)
 
 	if err != nil {
@@ -487,12 +455,8 @@ func (client *gocloak) UpdateUser(token string, realm string, user User) error {
 
 // UpdateUser creates a new user
 func (client *gocloak) UpdateGroup(token string, realm string, group Group) error {
-	bytes, err := json.Marshal(group)
-	if err != nil {
-		return err
-	}
 	resp, err := getRequestWithBearerAuth(token).
-		SetBody(string(bytes)).
+		SetBody(group).
 		Put(client.basePath + authRealm + realm + "/groups/" + group.ID)
 
 	if err != nil {
@@ -508,12 +472,8 @@ func (client *gocloak) UpdateGroup(token string, realm string, group Group) erro
 
 // UpdateUser creates a new user
 func (client *gocloak) UpdateClient(token string, realm string, newClient Client) error {
-	bytes, err := json.Marshal(newClient)
-	if err != nil {
-		return err
-	}
 	resp, err := getRequestWithBearerAuth(token).
-		SetBody(string(bytes)).
+		SetBody(newClient).
 		Put(client.basePath + authRealm + realm + "/clients")
 
 	if err != nil {
@@ -529,12 +489,8 @@ func (client *gocloak) UpdateClient(token string, realm string, newClient Client
 
 // UpdateUser creates a new user
 func (client *gocloak) UpdateRole(token string, realm string, clientID string, role Role) error {
-	bytes, err := json.Marshal(role)
-	if err != nil {
-		return err
-	}
 	resp, err := getRequestWithBearerAuth(token).
-		SetBody(string(bytes)).
+		SetBody(role).
 		Put(client.basePath + authRealm + realm + "/clients/" + clientID + "/roles/" + role.Name)
 
 	if err != nil {
@@ -550,12 +506,8 @@ func (client *gocloak) UpdateRole(token string, realm string, clientID string, r
 
 // UpdateClientScope creates a new client scope
 func (client *gocloak) UpdateClientScope(token string, realm string, scope ClientScope) error {
-	bytes, err := json.Marshal(scope)
-	if err != nil {
-		return err
-	}
 	resp, err := getRequestWithBearerAuth(token).
-		SetBody(string(bytes)).
+		SetBody(scope).
 		Put(client.basePath + authRealm + realm + "/client-scopes/" + scope.ID)
 
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -619,7 +619,9 @@ func (client *gocloak) DeleteClientScope(token string, realm string, scopeID str
 
 // GetKeyStoreConfig get keystoreconfig of the realm
 func (client *gocloak) GetKeyStoreConfig(token string, realm string) (*KeyStoreConfig, error) {
+	var result KeyStoreConfig
 	resp, err := getRequestWithBearerAuth(token).
+		SetResult(&result).
 		Get(client.basePath + authRealm + realm + "/keys")
 	if err != nil {
 		return nil, err
@@ -627,11 +629,6 @@ func (client *gocloak) GetKeyStoreConfig(token string, realm string) (*KeyStoreC
 
 	if resp.StatusCode() != 200 {
 		return nil, errors.New(resp.Status())
-	}
-
-	var result KeyStoreConfig
-	if err := json.Unmarshal(resp.Body(), &result); err != nil {
-		return nil, err
 	}
 
 	return &result, nil
@@ -794,14 +791,11 @@ func (client *gocloak) GetGroup(token string, realm string, groupID string) (*Gr
 
 // GetGroups get all groups in realm
 func (client *gocloak) GetGroups(token string, realm string) (*[]Group, error) {
-	resp, err := getRequestWithBearerAuth(token).
+	var result []Group
+	_, err := getRequestWithBearerAuth(token).
+		SetResult(&result).
 		Get(client.basePath + authRealm + realm + "/groups")
 	if err != nil {
-		return nil, err
-	}
-
-	var result []Group
-	if err := json.Unmarshal(resp.Body(), &result); err != nil {
 		return nil, err
 	}
 
@@ -810,14 +804,11 @@ func (client *gocloak) GetGroups(token string, realm string) (*[]Group, error) {
 
 // GetRoles get all roles in realm
 func (client *gocloak) GetRoles(token string, realm string) (*[]Role, error) {
-	resp, err := getRequestWithBearerAuth(token).
+	var result []Role
+	_, err := getRequestWithBearerAuth(token).
+		SetResult(&result).
 		Get(client.basePath + authRealm + realm + "/roles")
 	if err != nil {
-		return nil, err
-	}
-
-	var result []Role
-	if err := json.Unmarshal(resp.Body(), &result); err != nil {
 		return nil, err
 	}
 
@@ -881,14 +872,11 @@ func getRequestWithBasicAuth(clientID string, clientSecret string) *resty.Reques
 
 // GetRealmRolesByUserID gets the roles by user
 func (client *gocloak) GetRealmRolesByUserID(token string, realm string, userID string) (*[]Role, error) {
-	resp, err := getRequestWithBearerAuth(token).
+	var result []Role
+	_, err := getRequestWithBearerAuth(token).
+		SetResult(&result).
 		Get(client.basePath + authRealm + realm + "/users/" + userID + "/role-mappings/realm")
 	if err != nil {
-		return nil, err
-	}
-
-	var result []Role
-	if err := json.Unmarshal(resp.Body(), &result); err != nil {
 		return nil, err
 	}
 
@@ -897,14 +885,10 @@ func (client *gocloak) GetRealmRolesByUserID(token string, realm string, userID 
 
 // GetRealmRolesByGroupID gets the roles by group
 func (client *gocloak) GetRealmRolesByGroupID(token string, realm string, groupID string) (*[]Role, error) {
-	resp, err := getRequestWithBearerAuth(token).
+	var result []Role
+	_, err := getRequestWithBearerAuth(token).
 		Get(client.basePath + authRealm + realm + "/groups/" + groupID + "/role-mappings/realm")
 	if err != nil {
-		return nil, err
-	}
-
-	var result []Role
-	if err := json.Unmarshal(resp.Body(), &result); err != nil {
 		return nil, err
 	}
 

--- a/client.go
+++ b/client.go
@@ -45,12 +45,9 @@ func (client *gocloak) GetCerts(realm string) (*CertResponse, error) {
 	resp, err := resty.R().
 		SetResult(&result).
 		Get(client.basePath + authRealms + realm + openIdConnect + "/certs")
+	err = checkForError(resp, err)
 	if err != nil {
 		return nil, err
-	}
-
-	if resp.StatusCode() != 200 {
-		return nil, errors.New(resp.Status())
 	}
 
 	return &result, nil
@@ -62,12 +59,9 @@ func (client *gocloak) GetIssuer(realm string) (*IssuerResponse, error) {
 	resp, err := resty.R().
 		SetResult(&result).
 		Get(client.basePath + authRealms + realm)
+	err = checkForError(resp, err)
 	if err != nil {
 		return nil, err
-	}
-
-	if resp.StatusCode() != 200 {
-		return nil, errors.New(resp.Status())
 	}
 
 	return &result, nil
@@ -83,12 +77,9 @@ func (client *gocloak) RetrospectToken(accessToken string, clientID, clientSecre
 		}).
 		SetResult(&result).
 		Post(client.basePath + authRealms + realm + tokenEndpoint + "/introspect")
+	err = checkForError(resp, err)
 	if err != nil {
 		return nil, err
-	}
-
-	if resp.StatusCode() != 200 {
-		return nil, errors.New(resp.Status())
 	}
 
 	return &result, nil
@@ -270,12 +261,9 @@ func (client *gocloak) Login(clientID string, clientSecret string, realm string,
 		}).
 		SetResult(&result).
 		Post(client.basePath + authRealms + realm + tokenEndpoint)
+	err = checkForError(resp, err)
 	if err != nil {
 		return nil, err
-	}
-
-	if resp.StatusCode() != 200 {
-		log.Println(string(resp.Body()))
 	}
 
 	if result.AccessToken == "" {
@@ -297,12 +285,9 @@ func (client *gocloak) RequestPermission(clientID string, clientSecret string, r
 		}).
 		SetResult(&result).
 		Post(client.basePath + authRealms + realm + tokenEndpoint)
+	err = checkForError(resp, err)
 	if err != nil {
 		return nil, err
-	}
-
-	if resp.StatusCode() != 200 {
-		log.Println(string(resp.Body()))
 	}
 
 	if result.AccessToken == "" {
@@ -318,13 +303,9 @@ func (client *gocloak) SetPassword(token string, userID string, realm string, pa
 	resp, err := getRequestWithBearerAuth(token).
 		SetBody(requestBody).
 		Put(client.basePath + authRealm + realm + "/users/" + userID + "/reset-password")
-
+	err = checkForError(resp, err, 201, 204, 409)
 	if err != nil {
 		return err
-	}
-
-	if resp.StatusCode() != 201 && resp.StatusCode() != 204 && resp.StatusCode() != 409 {
-		return errors.New(resp.Status())
 	}
 
 	return nil
@@ -336,12 +317,9 @@ func (client *gocloak) CreateUser(token string, realm string, user User) (*strin
 		SetBody(user).
 		Post(client.basePath + authRealm + realm + "/users")
 
+	err = checkForError(resp, err, 201, 204, 409)
 	if err != nil {
 		return nil, err
-	}
-
-	if resp.StatusCode() != 201 && resp.StatusCode() != 204 && resp.StatusCode() != 409 {
-		return nil, errors.New(resp.Status())
 	}
 
 	userPath := resp.Header().Get("Location")
@@ -357,12 +335,9 @@ func (client *gocloak) CreateGroup(token string, realm string, group Group) erro
 		SetBody(group).
 		Post(client.basePath + authRealm + realm + "/groups")
 
+	err = checkForError(resp, err, 201, 409)
 	if err != nil {
 		return err
-	}
-
-	if resp.StatusCode() != 201 && resp.StatusCode() != 409 {
-		return errors.New(resp.Status())
 	}
 
 	return nil
@@ -374,12 +349,9 @@ func (client *gocloak) CreateComponent(token string, realm string, component Com
 		SetBody(component).
 		Post(client.basePath + authRealm + realm + "/components")
 
+	err = checkForError(resp, err, 201, 409)
 	if err != nil {
 		return err
-	}
-
-	if resp.StatusCode() != 201 && resp.StatusCode() != 409 {
-		return errors.New(resp.Status())
 	}
 
 	return nil
@@ -391,12 +363,9 @@ func (client *gocloak) CreateClient(token string, realm string, newClient Client
 		SetBody(newClient).
 		Post(client.basePath + authRealm + realm + "/clients")
 
+	err = checkForError(resp, err, 201, 409)
 	if err != nil {
 		return err
-	}
-
-	if resp.StatusCode() != 201 && resp.StatusCode() != 409 {
-		return errors.New(resp.Status())
 	}
 
 	return nil
@@ -408,12 +377,9 @@ func (client *gocloak) CreateRole(token string, realm string, clientID string, r
 		SetBody(role).
 		Post(client.basePath + authRealm + realm + "clients/" + clientID + "/roles")
 
+	err = checkForError(resp, err, 201, 409)
 	if err != nil {
 		return err
-	}
-
-	if resp.StatusCode() != 201 && resp.StatusCode() != 409 {
-		return errors.New(resp.Status())
 	}
 
 	return nil
@@ -425,12 +391,9 @@ func (client *gocloak) CreateClientScope(token string, realm string, scope Clien
 		SetBody(scope).
 		Post(client.basePath + authRealm + realm + "/client-scopes")
 
+	err = checkForError(resp, err, 201, 409)
 	if err != nil {
 		return err
-	}
-
-	if resp.StatusCode() != 201 && resp.StatusCode() != 409 {
-		return errors.New(resp.Status())
 	}
 
 	return nil
@@ -442,12 +405,9 @@ func (client *gocloak) UpdateUser(token string, realm string, user User) error {
 		SetBody(user).
 		Put(client.basePath + authRealm + realm + "/users/" + user.ID)
 
+	err = checkForError(resp, err, 201)
 	if err != nil {
 		return err
-	}
-
-	if resp.StatusCode() != 201 {
-		return errors.New(resp.Status())
 	}
 
 	return nil
@@ -459,12 +419,9 @@ func (client *gocloak) UpdateGroup(token string, realm string, group Group) erro
 		SetBody(group).
 		Put(client.basePath + authRealm + realm + "/groups/" + group.ID)
 
+	err = checkForError(resp, err, 201)
 	if err != nil {
 		return err
-	}
-
-	if resp.StatusCode() != 201 {
-		return errors.New(resp.Status())
 	}
 
 	return nil
@@ -476,12 +433,9 @@ func (client *gocloak) UpdateClient(token string, realm string, newClient Client
 		SetBody(newClient).
 		Put(client.basePath + authRealm + realm + "/clients")
 
+	err = checkForError(resp, err, 201)
 	if err != nil {
 		return err
-	}
-
-	if resp.StatusCode() != 201 {
-		return errors.New(resp.Status())
 	}
 
 	return nil
@@ -493,12 +447,9 @@ func (client *gocloak) UpdateRole(token string, realm string, clientID string, r
 		SetBody(role).
 		Put(client.basePath + authRealm + realm + "/clients/" + clientID + "/roles/" + role.Name)
 
+	err = checkForError(resp, err, 201)
 	if err != nil {
 		return err
-	}
-
-	if resp.StatusCode() != 201 {
-		return errors.New(resp.Status())
 	}
 
 	return nil
@@ -510,12 +461,9 @@ func (client *gocloak) UpdateClientScope(token string, realm string, scope Clien
 		SetBody(scope).
 		Put(client.basePath + authRealm + realm + "/client-scopes/" + scope.ID)
 
+	err = checkForError(resp, err, 201)
 	if err != nil {
 		return err
-	}
-
-	if resp.StatusCode() != 201 {
-		return errors.New(resp.Status())
 	}
 
 	return nil
@@ -526,12 +474,9 @@ func (client *gocloak) DeleteUser(token string, realm string, userID string) err
 	resp, err := getRequestWithBearerAuth(token).
 		Delete(client.basePath + authRealm + realm + "/users/" + userID)
 
+	err = checkForError(resp, err, 201)
 	if err != nil {
 		return err
-	}
-
-	if resp.StatusCode() != 201 {
-		return errors.New(resp.Status())
 	}
 
 	return nil
@@ -542,12 +487,9 @@ func (client *gocloak) DeleteGroup(token string, realm string, groupID string) e
 	resp, err := getRequestWithBearerAuth(token).
 		Delete(client.basePath + authRealm + realm + "/groups/" + groupID)
 
+	err = checkForError(resp, err, 201)
 	if err != nil {
 		return err
-	}
-
-	if resp.StatusCode() != 201 {
-		return errors.New(resp.Status())
 	}
 
 	return nil
@@ -558,12 +500,9 @@ func (client *gocloak) DeleteClient(token string, realm string, clientID string)
 	resp, err := getRequestWithBearerAuth(token).
 		Delete(client.basePath + authRealm + realm + "/clients/" + clientID)
 
+	err = checkForError(resp, err, 201)
 	if err != nil {
 		return err
-	}
-
-	if resp.StatusCode() != 201 {
-		return errors.New(resp.Status())
 	}
 
 	return nil
@@ -574,12 +513,9 @@ func (client *gocloak) DeleteComponent(token string, realm string, componentID s
 	resp, err := getRequestWithBearerAuth(token).
 		Delete(client.basePath + authRealm + realm + "/components/" + componentID)
 
+	err = checkForError(resp, err, 201)
 	if err != nil {
 		return err
-	}
-
-	if resp.StatusCode() != 201 {
-		return errors.New(resp.Status())
 	}
 
 	return nil
@@ -590,12 +526,9 @@ func (client *gocloak) DeleteRole(token string, realm string, clientID, roleName
 	resp, err := getRequestWithBearerAuth(token).
 		Delete(client.basePath + authRealm + realm + "/clients/" + clientID + "/roles/" + roleName)
 
+	err = checkForError(resp, err, 201)
 	if err != nil {
 		return err
-	}
-
-	if resp.StatusCode() != 201 {
-		return errors.New(resp.Status())
 	}
 
 	return nil
@@ -606,12 +539,9 @@ func (client *gocloak) DeleteClientScope(token string, realm string, scopeID str
 	resp, err := getRequestWithBearerAuth(token).
 		Put(client.basePath + authRealm + realm + "/client-scopes/" + scopeID)
 
+	err = checkForError(resp, err, 201)
 	if err != nil {
 		return err
-	}
-
-	if resp.StatusCode() != 201 {
-		return errors.New(resp.Status())
 	}
 
 	return nil
@@ -623,12 +553,10 @@ func (client *gocloak) GetKeyStoreConfig(token string, realm string) (*KeyStoreC
 	resp, err := getRequestWithBearerAuth(token).
 		SetResult(&result).
 		Get(client.basePath + authRealm + realm + "/keys")
+
+	err = checkForError(resp, err)
 	if err != nil {
 		return nil, err
-	}
-
-	if resp.StatusCode() != 200 {
-		return nil, errors.New(resp.Status())
 	}
 
 	return &result, nil
@@ -641,10 +569,11 @@ func (client *gocloak) GetUserByID(accessToken string, realm string, userID stri
 	}
 
 	var result User
-	_, err := getRequestWithBearerAuth(accessToken).
+	resp, err := getRequestWithBearerAuth(accessToken).
 		SetResult(&result).
 		Get(client.basePath + authRealm + realm + "/users/" + userID)
 
+	err = checkForError(resp, err)
 	if err != nil {
 		return nil, err
 	}
@@ -655,9 +584,11 @@ func (client *gocloak) GetUserByID(accessToken string, realm string, userID stri
 // GetComponents get all cimponents in realm
 func (client *gocloak) GetComponents(token string, realm string) (*[]Component, error) {
 	var result []Component
-	_, err := getRequestWithBearerAuth(token).
+	resp, err := getRequestWithBearerAuth(token).
 		SetResult(&result).
 		Get(client.basePath + authRealm + realm + "/components")
+
+	err = checkForError(resp, err)
 	if err != nil {
 		return nil, err
 	}
@@ -668,9 +599,11 @@ func (client *gocloak) GetComponents(token string, realm string) (*[]Component, 
 // GetUsers get all users in realm
 func (client *gocloak) GetUsers(token string, realm string) (*[]User, error) {
 	var result []User
-	_, err := getRequestWithBearerAuth(token).
+	resp, err := getRequestWithBearerAuth(token).
 		SetResult(&result).
 		Get(client.basePath + authRealm + realm + "/users")
+
+	err = checkForError(resp, err)
 	if err != nil {
 		return nil, err
 	}
@@ -681,9 +614,11 @@ func (client *gocloak) GetUsers(token string, realm string) (*[]User, error) {
 // GetUserCount gets the user count in the realm
 func (client *gocloak) GetUserCount(token string, realm string) (int, error) {
 	var result int
-	_, err := getRequestWithBearerAuth(token).
+	resp, err := getRequestWithBearerAuth(token).
 		SetResult(&result).
 		Get(client.basePath + authRealm + realm + "/users/count")
+
+	err = checkForError(resp, err)
 	if err != nil {
 		return -1, err
 	}
@@ -694,9 +629,11 @@ func (client *gocloak) GetUserCount(token string, realm string) (int, error) {
 // GetUsergroups get all groups for user
 func (client *gocloak) GetUserGroups(token string, realm string, userID string) (*[]UserGroup, error) {
 	var result []UserGroup
-	_, err := getRequestWithBearerAuth(token).
+	resp, err := getRequestWithBearerAuth(token).
 		SetResult(&result).
 		Get(client.basePath + authRealm + realm + "/users/" + userID + "/groups")
+
+	err = checkForError(resp, err)
 	if err != nil {
 		return nil, err
 	}
@@ -708,6 +645,8 @@ func (client *gocloak) GetUserGroups(token string, realm string, userID string) 
 func (client *gocloak) GetRoleMappingByGroupID(token string, realm string, groupID string) (*[]RoleMapping, error) {
 	resp, err := getRequestWithBearerAuth(token).
 		Get(client.basePath + authRealm + realm + "/groups/" + groupID + "/role-mappings")
+
+	err = checkForError(resp, err)
 	if err != nil {
 		return nil, err
 	}
@@ -744,6 +683,8 @@ func (client *gocloak) GetRoleMappingByGroupID(token string, realm string, group
 func (client *gocloak) GetRoleMappingByUserID(token string, realm string, userID string) (*[]RoleMapping, error) {
 	resp, err := getRequestWithBearerAuth(token).
 		Get(client.basePath + authRealm + realm + "/users/" + userID + "/role-mappings")
+
+	err = checkForError(resp, err)
 	if err != nil {
 		return nil, err
 	}
@@ -779,9 +720,11 @@ func (client *gocloak) GetRoleMappingByUserID(token string, realm string, userID
 // GetGroup get group with id in realm
 func (client *gocloak) GetGroup(token string, realm string, groupID string) (*Group, error) {
 	var result Group
-	_, err := getRequestWithBearerAuth(token).
+	resp, err := getRequestWithBearerAuth(token).
 		SetResult(&result).
 		Get(client.basePath + authRealm + realm + "/group/" + groupID)
+
+	err = checkForError(resp, err)
 	if err != nil {
 		return nil, err
 	}
@@ -792,9 +735,11 @@ func (client *gocloak) GetGroup(token string, realm string, groupID string) (*Gr
 // GetGroups get all groups in realm
 func (client *gocloak) GetGroups(token string, realm string) (*[]Group, error) {
 	var result []Group
-	_, err := getRequestWithBearerAuth(token).
+	resp, err := getRequestWithBearerAuth(token).
 		SetResult(&result).
 		Get(client.basePath + authRealm + realm + "/groups")
+
+	err = checkForError(resp, err)
 	if err != nil {
 		return nil, err
 	}
@@ -805,9 +750,11 @@ func (client *gocloak) GetGroups(token string, realm string) (*[]Group, error) {
 // GetRoles get all roles in realm
 func (client *gocloak) GetRoles(token string, realm string) (*[]Role, error) {
 	var result []Role
-	_, err := getRequestWithBearerAuth(token).
+	resp, err := getRequestWithBearerAuth(token).
 		SetResult(&result).
 		Get(client.basePath + authRealm + realm + "/roles")
+
+	err = checkForError(resp, err)
 	if err != nil {
 		return nil, err
 	}
@@ -818,13 +765,14 @@ func (client *gocloak) GetRoles(token string, realm string) (*[]Role, error) {
 // GetRolesByClientID get all roles for the given client in realm
 func (client *gocloak) GetRolesByClientID(token string, realm string, clientID string) (*[]Role, error) {
 	var result []Role
-	_, err := getRequestWithBearerAuth(token).
+	resp, err := getRequestWithBearerAuth(token).
 		SetResult(&result).
 		Get(client.basePath + authRealm + realm + "/clients/" + clientID + "/roles")
+
+	err = checkForError(resp, err)
 	if err != nil {
 		return nil, err
 	}
-	// ioutil.WriteFile("test.json", resp.Body(), 0644)
 
 	return &result, nil
 }
@@ -832,9 +780,11 @@ func (client *gocloak) GetRolesByClientID(token string, realm string, clientID s
 // GetClients gets all clients in realm
 func (client *gocloak) GetClients(token string, realm string) (*[]Client, error) {
 	var result []Client
-	_, err := getRequestWithBearerAuth(token).
+	resp, err := getRequestWithBearerAuth(token).
 		SetResult(&result).
 		Get(client.basePath + authRealm + realm + "/clients")
+
+	err = checkForError(resp, err)
 	if err != nil {
 		return nil, err
 	}
@@ -873,9 +823,11 @@ func getRequestWithBasicAuth(clientID string, clientSecret string) *resty.Reques
 // GetRealmRolesByUserID gets the roles by user
 func (client *gocloak) GetRealmRolesByUserID(token string, realm string, userID string) (*[]Role, error) {
 	var result []Role
-	_, err := getRequestWithBearerAuth(token).
+	resp, err := getRequestWithBearerAuth(token).
 		SetResult(&result).
 		Get(client.basePath + authRealm + realm + "/users/" + userID + "/role-mappings/realm")
+
+	err = checkForError(resp, err)
 	if err != nil {
 		return nil, err
 	}
@@ -886,11 +838,31 @@ func (client *gocloak) GetRealmRolesByUserID(token string, realm string, userID 
 // GetRealmRolesByGroupID gets the roles by group
 func (client *gocloak) GetRealmRolesByGroupID(token string, realm string, groupID string) (*[]Role, error) {
 	var result []Role
-	_, err := getRequestWithBearerAuth(token).
+	resp, err := getRequestWithBearerAuth(token).
 		Get(client.basePath + authRealm + realm + "/groups/" + groupID + "/role-mappings/realm")
+
+	err = checkForError(resp, err)
 	if err != nil {
 		return nil, err
 	}
 
 	return &result, nil
+}
+
+func checkForError(resp *resty.Response, err error, validStatusCodes ...int) error {
+	if err != nil {
+		return err
+	}
+	if len(validStatusCodes) == 0 {
+		validStatusCodes = append(validStatusCodes,200)
+	}
+	statusCode := resp.StatusCode()
+	for _, code := range validStatusCodes {
+		if code == statusCode {
+			return nil
+		}
+	}
+	log.Printf("Error: Request returned a response with status '%s' and body: %s", resp.Status(), string(resp.Body()))
+	return errors.New(resp.Status())
+
 }

--- a/client.go
+++ b/client.go
@@ -76,9 +76,7 @@ func (client *gocloak) GetIssuer(realm string) (*IssuerResponse, error) {
 // RetrospectToken calls the openid-connect introspect endpoint
 func (client *gocloak) RetrospectToken(accessToken string, clientID, clientSecret string, realm string) (*RetrospecTokenResult, error) {
 	var result RetrospecTokenResult
-	resp, err := resty.R().
-		SetHeader("Content-Type", "application/x-www-form-urlencoded").
-		SetHeader("Authorization", getBasicAuthForClient(clientID, clientSecret)).
+	resp, err := getRequestWithBasicAuth(clientID, clientSecret).
 		SetFormData(map[string]string{
 			"token_type_hint": "requesting_party_token",
 			"token":           accessToken,
@@ -264,9 +262,7 @@ func (client *gocloak) LoginClient(clientID, clientSecret, realm string) (*JWT, 
 // Login like login, but with basic auth
 func (client *gocloak) Login(clientID string, clientSecret string, realm string, username string, password string) (*JWT, error) {
 	var result JWT
-	resp, err := resty.R().
-		SetHeader("Content-Type", "application/x-www-form-urlencoded").
-		SetHeader("Authorization", getBasicAuthForClient(clientID, clientSecret)).
+	resp, err := getRequestWithBasicAuth(clientID, clientSecret).
 		SetFormData(map[string]string{
 			"grant_type": "password",
 			"username":   username,
@@ -292,9 +288,7 @@ func (client *gocloak) Login(clientID string, clientSecret string, realm string,
 // RequestPermission l
 func (client *gocloak) RequestPermission(clientID string, clientSecret string, realm string, username string, password string, permission string) (*JWT, error) {
 	var result JWT
-	resp, err := resty.R().
-		SetHeader("Content-Type", "application/x-www-form-urlencoded").
-		SetHeader("Authorization", getBasicAuthForClient(clientID, clientSecret)).
+	resp, err := getRequestWithBasicAuth(clientID, clientSecret).
 		SetFormData(map[string]string{
 			"grant_type": "password",
 			"username":   username,
@@ -325,7 +319,7 @@ func (client *gocloak) SetPassword(token string, userID string, realm string, pa
 	if err != nil {
 		return err
 	}
-	resp, err := getRequestWithHeader(token).
+	resp, err := getRequestWithBearerAuth(token).
 		SetBody(string(bytes)).
 		Put(client.basePath + authRealm + realm + "/users/" + userID + "/reset-password")
 
@@ -346,7 +340,7 @@ func (client *gocloak) CreateUser(token string, realm string, user User) (*strin
 	if err != nil {
 		return nil, err
 	}
-	resp, err := getRequestWithHeader(token).
+	resp, err := getRequestWithBearerAuth(token).
 		SetBody(string(bytes)).
 		Post(client.basePath + authRealm + realm + "/users")
 
@@ -371,7 +365,7 @@ func (client *gocloak) CreateGroup(token string, realm string, group Group) erro
 	if err != nil {
 		return err
 	}
-	resp, err := getRequestWithHeader(token).
+	resp, err := getRequestWithBearerAuth(token).
 		SetBody(string(bytes)).
 		Post(client.basePath + authRealm + realm + "/groups")
 
@@ -392,7 +386,7 @@ func (client *gocloak) CreateComponent(token string, realm string, component Com
 	if err != nil {
 		return err
 	}
-	resp, err := getRequestWithHeader(token).
+	resp, err := getRequestWithBearerAuth(token).
 		SetBody(string(bytes)).
 		Post(client.basePath + authRealm + realm + "/components")
 
@@ -413,7 +407,7 @@ func (client *gocloak) CreateClient(token string, realm string, newClient Client
 	if err != nil {
 		return err
 	}
-	resp, err := getRequestWithHeader(token).
+	resp, err := getRequestWithBearerAuth(token).
 		SetBody(string(bytes)).
 		Post(client.basePath + authRealm + realm + "/clients")
 
@@ -434,7 +428,7 @@ func (client *gocloak) CreateRole(token string, realm string, clientID string, r
 	if err != nil {
 		return err
 	}
-	resp, err := getRequestWithHeader(token).
+	resp, err := getRequestWithBearerAuth(token).
 		SetBody(string(bytes)).
 		Post(client.basePath + authRealm + realm + "clients/" + clientID + "/roles")
 
@@ -455,7 +449,7 @@ func (client *gocloak) CreateClientScope(token string, realm string, scope Clien
 	if err != nil {
 		return err
 	}
-	resp, err := getRequestWithHeader(token).
+	resp, err := getRequestWithBearerAuth(token).
 		SetBody(string(bytes)).
 		Post(client.basePath + authRealm + realm + "/client-scopes")
 
@@ -476,7 +470,7 @@ func (client *gocloak) UpdateUser(token string, realm string, user User) error {
 	if err != nil {
 		return err
 	}
-	resp, err := getRequestWithHeader(token).
+	resp, err := getRequestWithBearerAuth(token).
 		SetBody(string(bytes)).
 		Put(client.basePath + authRealm + realm + "/users/" + user.ID)
 
@@ -497,7 +491,7 @@ func (client *gocloak) UpdateGroup(token string, realm string, group Group) erro
 	if err != nil {
 		return err
 	}
-	resp, err := getRequestWithHeader(token).
+	resp, err := getRequestWithBearerAuth(token).
 		SetBody(string(bytes)).
 		Put(client.basePath + authRealm + realm + "/groups/" + group.ID)
 
@@ -518,7 +512,7 @@ func (client *gocloak) UpdateClient(token string, realm string, newClient Client
 	if err != nil {
 		return err
 	}
-	resp, err := getRequestWithHeader(token).
+	resp, err := getRequestWithBearerAuth(token).
 		SetBody(string(bytes)).
 		Put(client.basePath + authRealm + realm + "/clients")
 
@@ -539,7 +533,7 @@ func (client *gocloak) UpdateRole(token string, realm string, clientID string, r
 	if err != nil {
 		return err
 	}
-	resp, err := getRequestWithHeader(token).
+	resp, err := getRequestWithBearerAuth(token).
 		SetBody(string(bytes)).
 		Put(client.basePath + authRealm + realm + "/clients/" + clientID + "/roles/" + role.Name)
 
@@ -560,7 +554,7 @@ func (client *gocloak) UpdateClientScope(token string, realm string, scope Clien
 	if err != nil {
 		return err
 	}
-	resp, err := getRequestWithHeader(token).
+	resp, err := getRequestWithBearerAuth(token).
 		SetBody(string(bytes)).
 		Put(client.basePath + authRealm + realm + "/client-scopes/" + scope.ID)
 
@@ -577,7 +571,7 @@ func (client *gocloak) UpdateClientScope(token string, realm string, scope Clien
 
 // DeleteUser creates a new user
 func (client *gocloak) DeleteUser(token string, realm string, userID string) error {
-	resp, err := getRequestWithHeader(token).
+	resp, err := getRequestWithBearerAuth(token).
 		Delete(client.basePath + authRealm + realm + "/users/" + userID)
 
 	if err != nil {
@@ -593,7 +587,7 @@ func (client *gocloak) DeleteUser(token string, realm string, userID string) err
 
 // DeleteUser creates a new user
 func (client *gocloak) DeleteGroup(token string, realm string, groupID string) error {
-	resp, err := getRequestWithHeader(token).
+	resp, err := getRequestWithBearerAuth(token).
 		Delete(client.basePath + authRealm + realm + "/groups/" + groupID)
 
 	if err != nil {
@@ -609,7 +603,7 @@ func (client *gocloak) DeleteGroup(token string, realm string, groupID string) e
 
 // DeleteUser creates a new user
 func (client *gocloak) DeleteClient(token string, realm string, clientID string) error {
-	resp, err := getRequestWithHeader(token).
+	resp, err := getRequestWithBearerAuth(token).
 		Delete(client.basePath + authRealm + realm + "/clients/" + clientID)
 
 	if err != nil {
@@ -625,7 +619,7 @@ func (client *gocloak) DeleteClient(token string, realm string, clientID string)
 
 // DeleteComponent creates a new user
 func (client *gocloak) DeleteComponent(token string, realm string, componentID string) error {
-	resp, err := getRequestWithHeader(token).
+	resp, err := getRequestWithBearerAuth(token).
 		Delete(client.basePath + authRealm + realm + "/components/" + componentID)
 
 	if err != nil {
@@ -641,7 +635,7 @@ func (client *gocloak) DeleteComponent(token string, realm string, componentID s
 
 // DeleteUser creates a new user
 func (client *gocloak) DeleteRole(token string, realm string, clientID, roleName string) error {
-	resp, err := getRequestWithHeader(token).
+	resp, err := getRequestWithBearerAuth(token).
 		Delete(client.basePath + authRealm + realm + "/clients/" + clientID + "/roles/" + roleName)
 
 	if err != nil {
@@ -657,7 +651,7 @@ func (client *gocloak) DeleteRole(token string, realm string, clientID, roleName
 
 // DeleteClientScope creates a new client scope
 func (client *gocloak) DeleteClientScope(token string, realm string, scopeID string) error {
-	resp, err := getRequestWithHeader(token).
+	resp, err := getRequestWithBearerAuth(token).
 		Put(client.basePath + authRealm + realm + "/client-scopes/" + scopeID)
 
 	if err != nil {
@@ -673,7 +667,7 @@ func (client *gocloak) DeleteClientScope(token string, realm string, scopeID str
 
 // GetKeyStoreConfig get keystoreconfig of the realm
 func (client *gocloak) GetKeyStoreConfig(token string, realm string) (*KeyStoreConfig, error) {
-	resp, err := getRequestWithHeader(token).
+	resp, err := getRequestWithBearerAuth(token).
 		Get(client.basePath + authRealm + realm + "/keys")
 	if err != nil {
 		return nil, err
@@ -698,7 +692,7 @@ func (client *gocloak) GetUserByID(accessToken string, realm string, userID stri
 	}
 
 	var result User
-	_, err := getRequestWithHeader(accessToken).
+	_, err := getRequestWithBearerAuth(accessToken).
 		SetResult(&result).
 		Get(client.basePath + authRealm + realm + "/users/" + userID)
 
@@ -712,7 +706,7 @@ func (client *gocloak) GetUserByID(accessToken string, realm string, userID stri
 // GetComponents get all cimponents in realm
 func (client *gocloak) GetComponents(token string, realm string) (*[]Component, error) {
 	var result []Component
-	_, err := getRequestWithHeader(token).
+	_, err := getRequestWithBearerAuth(token).
 		SetResult(&result).
 		Get(client.basePath + authRealm + realm + "/components")
 	if err != nil {
@@ -725,7 +719,7 @@ func (client *gocloak) GetComponents(token string, realm string) (*[]Component, 
 // GetUsers get all users in realm
 func (client *gocloak) GetUsers(token string, realm string) (*[]User, error) {
 	var result []User
-	_, err := getRequestWithHeader(token).
+	_, err := getRequestWithBearerAuth(token).
 		SetResult(&result).
 		Get(client.basePath + authRealm + realm + "/users")
 	if err != nil {
@@ -738,7 +732,7 @@ func (client *gocloak) GetUsers(token string, realm string) (*[]User, error) {
 // GetUserCount gets the user count in the realm
 func (client *gocloak) GetUserCount(token string, realm string) (int, error) {
 	var result int
-	_, err := getRequestWithHeader(token).
+	_, err := getRequestWithBearerAuth(token).
 		SetResult(&result).
 		Get(client.basePath + authRealm + realm + "/users/count")
 	if err != nil {
@@ -751,7 +745,7 @@ func (client *gocloak) GetUserCount(token string, realm string) (int, error) {
 // GetUsergroups get all groups for user
 func (client *gocloak) GetUserGroups(token string, realm string, userID string) (*[]UserGroup, error) {
 	var result []UserGroup
-	_, err := getRequestWithHeader(token).
+	_, err := getRequestWithBearerAuth(token).
 		SetResult(&result).
 		Get(client.basePath + authRealm + realm + "/users/" + userID + "/groups")
 	if err != nil {
@@ -763,7 +757,7 @@ func (client *gocloak) GetUserGroups(token string, realm string, userID string) 
 
 // GetRoleMappingByGroupID gets the role mappings by group
 func (client *gocloak) GetRoleMappingByGroupID(token string, realm string, groupID string) (*[]RoleMapping, error) {
-	resp, err := getRequestWithHeader(token).
+	resp, err := getRequestWithBearerAuth(token).
 		Get(client.basePath + authRealm + realm + "/groups/" + groupID + "/role-mappings")
 	if err != nil {
 		return nil, err
@@ -799,7 +793,7 @@ func (client *gocloak) GetRoleMappingByGroupID(token string, realm string, group
 
 // GetRoleMappingByUserID gets the role mappings by user
 func (client *gocloak) GetRoleMappingByUserID(token string, realm string, userID string) (*[]RoleMapping, error) {
-	resp, err := getRequestWithHeader(token).
+	resp, err := getRequestWithBearerAuth(token).
 		Get(client.basePath + authRealm + realm + "/users/" + userID + "/role-mappings")
 	if err != nil {
 		return nil, err
@@ -836,7 +830,7 @@ func (client *gocloak) GetRoleMappingByUserID(token string, realm string, userID
 // GetGroup get group with id in realm
 func (client *gocloak) GetGroup(token string, realm string, groupID string) (*Group, error) {
 	var result Group
-	_, err := getRequestWithHeader(token).
+	_, err := getRequestWithBearerAuth(token).
 		SetResult(&result).
 		Get(client.basePath + authRealm + realm + "/group/" + groupID)
 	if err != nil {
@@ -848,7 +842,7 @@ func (client *gocloak) GetGroup(token string, realm string, groupID string) (*Gr
 
 // GetGroups get all groups in realm
 func (client *gocloak) GetGroups(token string, realm string) (*[]Group, error) {
-	resp, err := getRequestWithHeader(token).
+	resp, err := getRequestWithBearerAuth(token).
 		Get(client.basePath + authRealm + realm + "/groups")
 	if err != nil {
 		return nil, err
@@ -864,7 +858,7 @@ func (client *gocloak) GetGroups(token string, realm string) (*[]Group, error) {
 
 // GetRoles get all roles in realm
 func (client *gocloak) GetRoles(token string, realm string) (*[]Role, error) {
-	resp, err := getRequestWithHeader(token).
+	resp, err := getRequestWithBearerAuth(token).
 		Get(client.basePath + authRealm + realm + "/roles")
 	if err != nil {
 		return nil, err
@@ -881,7 +875,7 @@ func (client *gocloak) GetRoles(token string, realm string) (*[]Role, error) {
 // GetRolesByClientID get all roles for the given client in realm
 func (client *gocloak) GetRolesByClientID(token string, realm string, clientID string) (*[]Role, error) {
 	var result []Role
-	_, err := getRequestWithHeader(token).
+	_, err := getRequestWithBearerAuth(token).
 		SetResult(&result).
 		Get(client.basePath + authRealm + realm + "/clients/" + clientID + "/roles")
 	if err != nil {
@@ -895,7 +889,7 @@ func (client *gocloak) GetRolesByClientID(token string, realm string, clientID s
 // GetClients gets all clients in realm
 func (client *gocloak) GetClients(token string, realm string) (*[]Client, error) {
 	var result []Client
-	_, err := getRequestWithHeader(token).
+	_, err := getRequestWithBearerAuth(token).
 		SetResult(&result).
 		Get(client.basePath + authRealm + realm + "/clients")
 	if err != nil {
@@ -917,24 +911,25 @@ func (client *gocloak) UserAttributeContains(attributes map[string][]string, att
 	return false
 }
 
-func getRequestWithHeader(token string) *resty.Request {
+func getRequestWithBearerAuth(token string) *resty.Request {
 	return resty.R().
 		SetHeader("Content-Type", "application/json").
-		SetHeader("Authorization", "Bearer "+token)
+		SetHeader("Authorization", "Bearer " + token)
 }
 
-func getBasicAuthForClient(clientID string, clientSecret string) string {
+func getRequestWithBasicAuth(clientID string, clientSecret string) *resty.Request {
 	var httpBasicAuth string
 	if len(clientID) > 0 && len(clientSecret) > 0 {
 		httpBasicAuth = base64.URLEncoding.EncodeToString([]byte(clientID + ":" + clientSecret))
 	}
-
-	return "Basic " + httpBasicAuth
+	return resty.R().
+		SetHeader("Content-Type", "application/x-www-form-urlencoded").
+		SetHeader("Authorization", "Basic " + httpBasicAuth)
 }
 
 // GetRealmRolesByUserID gets the roles by user
 func (client *gocloak) GetRealmRolesByUserID(token string, realm string, userID string) (*[]Role, error) {
-	resp, err := getRequestWithHeader(token).
+	resp, err := getRequestWithBearerAuth(token).
 		Get(client.basePath + authRealm + realm + "/users/" + userID + "/role-mappings/realm")
 	if err != nil {
 		return nil, err
@@ -950,7 +945,7 @@ func (client *gocloak) GetRealmRolesByUserID(token string, realm string, userID 
 
 // GetRealmRolesByGroupID gets the roles by group
 func (client *gocloak) GetRealmRolesByGroupID(token string, realm string, groupID string) (*[]Role, error) {
-	resp, err := getRequestWithHeader(token).
+	resp, err := getRequestWithBearerAuth(token).
 		Get(client.basePath + authRealm + realm + "/groups/" + groupID + "/role-mappings/realm")
 	if err != nil {
 		return nil, err

--- a/client.go
+++ b/client.go
@@ -807,7 +807,7 @@ func (client *gocloak) UserAttributeContains(attributes map[string][]string, att
 func getRequestWithBearerAuth(token string) *resty.Request {
 	return resty.R().
 		SetHeader("Content-Type", "application/json").
-		SetHeader("Authorization", "Bearer " + token)
+		SetHeader("Authorization", "Bearer "+token)
 }
 
 func getRequestWithBasicAuth(clientID string, clientSecret string) *resty.Request {
@@ -817,7 +817,7 @@ func getRequestWithBasicAuth(clientID string, clientSecret string) *resty.Reques
 	}
 	return resty.R().
 		SetHeader("Content-Type", "application/x-www-form-urlencoded").
-		SetHeader("Authorization", "Basic " + httpBasicAuth)
+		SetHeader("Authorization", "Basic "+httpBasicAuth)
 }
 
 // GetRealmRolesByUserID gets the roles by user
@@ -854,7 +854,7 @@ func checkForError(resp *resty.Response, err error, validStatusCodes ...int) err
 		return err
 	}
 	if len(validStatusCodes) == 0 {
-		validStatusCodes = append(validStatusCodes,200)
+		validStatusCodes = append(validStatusCodes, 200)
 	}
 	statusCode := resp.StatusCode()
 	for _, code := range validStatusCodes {


### PR DESCRIPTION
Removing unnecessary SetHeader:
* The function `getRequestWithHeader` is already provides a request with `SetHeader("Content-Type", "application/json")`.

Refactoring `getRequestWith...` functions:
* Rename getRequestWithHeaders to getRequestWithBearerAuth function
* Add getRequestWithBasicAuth function

Remove marshalling objects for SetBody
* The resty is smart enough and it supports the automatic marshalling for JSON content type.

Use SetResult
* Using SetResult instead of unmarshalling as many as possible.

Check a response from a request for valid code
* Add function checkForError to validate that a request returned a response with valid code.