### PR TITLE
Refactoring GetRoleMappings functions

### DIFF
--- a/gocloak.go
+++ b/gocloak.go
@@ -91,9 +91,9 @@ type GoCloak interface {
 	// GetRoles get all roles of the given realm
 	GetRoles(accessToken string, realm string) (*[]Role, error)
 	// GetRoleMappingByGroupID gets the rolemapping for the given group id
-	GetRoleMappingByGroupID(accessToken string, realm string, groupID string) (*[]RoleMapping, error)
+	GetRoleMappingByGroupID(accessToken string, realm string, groupID string) (*MappingsRepresentation, error)
 	// GetRoleMappingByUserID gets the rolemapping for the given user id
-	GetRoleMappingByUserID(accessToken string, realm string, userID string) (*[]RoleMapping, error)
+	GetRoleMappingByUserID(accessToken string, realm string, userID string) (*MappingsRepresentation, error)
 	// GetRolesByClientID gets roles for the given client
 	GetRolesByClientID(accessToken string, realm string, clientID string) (*[]Role, error)
 	// GetClients gets the clients in the realm

--- a/models.go
+++ b/models.go
@@ -177,21 +177,16 @@ type Role struct {
 }
 
 // RoleMapping is a role mapping
-type RoleMapping struct {
-	ID       string                  `json:"id"`
-	Client   string                  `json:"client"`
-	Mappings []ClientRoleMappingRole `json:"mappings"`
+type ClientMappingsRepresentation struct {
+	ID       string `json:"id"`
+	Client   string `json:"client"`
+	Mappings []Role `json:"mappings"`
 }
 
-// ClientRoleMappingRole is a client role mapping role
-type ClientRoleMappingRole struct {
-	ID                 string `json:"id"`
-	Name               string `json:"name"`
-	Description        string `json:"description,omitempty"`
-	ScopeParamRequired bool   `json:"scopeParamRequired"`
-	Composite          bool   `json:"composite"`
-	ClientRole         bool   `json:"clientRole"`
-	ContainerID        string `json:"containerId"`
+// MappingsRepresentation is a representation of role mappings
+type MappingsRepresentation struct {
+	ClientMappings map[string]ClientMappingsRepresentation `json:"clientMappings,omitempty"`
+	RealmMappings  []Role                                  `json:"realmMappings,omitempty"`
 }
 
 // ClientScope is a ClientScope


### PR DESCRIPTION
Current implementation of GetRoleMappingByGroupID and GetRoleMappingByUserID is incorrect
and the functions don't return all mappings. They ignore RealmMappings.
Adding MappingsRepresentation structure and using it as a result of these functions solves
the problem, but breaks backward compatibility.
