### PR TITLE
Prevent, Sending parameters string with double quotes.

### DIFF
--- a/models.go
+++ b/models.go
@@ -163,13 +163,27 @@ type UserGroup struct {
 type GetUsersParams struct {
 	BaseParams
 	BriefRepresentation *bool  `json:"briefRepresentation,string,omitempty"`
-	Email               string `json:"email,string,omitempty"`
+	Email               string `json:"email,omitempty"`
 	First               int    `json:"first,string,omitempty"`
-	FirstName           string `json:"firstName,string,omitempty"`
-	LastName            string `json:"lastName,string,omitempty"`
+	FirstName           string `json:"firstName,omitempty"`
+	LastName            string `json:"lastName,omitempty"`
 	Max                 int    `json:"max,string,omitempty"`
-	Search              string `json:"search,string,omitempty"`
-	Username            string `json:"username,string,omitempty"`
+	Search              string `json:"search,omitempty"`
+	Username            string `json:"username,omitempty"`
+}
+
+// GetQueryParams converts the struct to map[string]string
+func (s GetUsersParams) GetQueryParams() (map[string]string, error) {
+	b, err := json.Marshal(s)
+	if err != nil {
+		return nil, err
+	}
+	var res map[string]string
+	err = json.Unmarshal(b, &res)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
 }
 
 // ExecuteActionsEmail represents parameters for executing action emails

--- a/models.go
+++ b/models.go
@@ -2,14 +2,8 @@ package gocloak
 
 import "encoding/json"
 
-// BaseParams provides basic functionality for all QueryParams structures.
-// The fields tags must have `json:"<name>,string,omitempty"` format.
-// "string" tag allows to convert the structure to map[string]string.
-// "omitempty" allows to skip the fields with default values.
-type BaseParams struct{}
-
-// GetQueryParams converts the struct to map[string]string
-func (s BaseParams) GetQueryParams() (map[string]string, error) {
+// getQueryParams converts the struct to map[string]string
+func getQueryParams(s interface{}) (map[string]string, error) {
 	b, err := json.Marshal(s)
 	if err != nil {
 		return nil, err
@@ -19,7 +13,18 @@ func (s BaseParams) GetQueryParams() (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return res, nil
+	return res, nil	
+}
+
+// BaseParams provides basic functionality for all QueryParams structures.
+// The fields tags must have `json:"<name>,string,omitempty"` format.
+// "string" tag allows to convert the structure to map[string]string.
+// "omitempty" allows to skip the fields with default values.
+type BaseParams struct{}
+
+// GetQueryParams converts the struct to map[string]string
+func (s BaseParams) GetQueryParams() (map[string]string, error) {
+	return getQueryParams(s)
 }
 
 // APIError represents an api error
@@ -174,26 +179,22 @@ type GetUsersParams struct {
 
 // GetQueryParams converts the struct to map[string]string
 func (s GetUsersParams) GetQueryParams() (map[string]string, error) {
-	b, err := json.Marshal(s)
-	if err != nil {
-		return nil, err
-	}
-	var res map[string]string
-	err = json.Unmarshal(b, &res)
-	if err != nil {
-		return nil, err
-	}
-	return res, nil
+	return getQueryParams(s)
 }
 
 // ExecuteActionsEmail represents parameters for executing action emails
 type ExecuteActionsEmail struct {
 	BaseParams
 	UserID      string   `json:"-"`
-	ClientID    string   `json:"clientId,string,omitempty"`
+	ClientID    string   `json:"clientId,omitempty"`
 	Lifespan    int      `json:"lifespan,string,omitempty"`
-	RedirectURI string   `json:"redirect_uri,string,omitempty"`
+	RedirectURI string   `json:"redirect_uri,omitempty"`
 	Actions     []string `json:"-"`
+}
+
+// GetQueryParams converts the struct to map[string]string
+func (s ExecuteActionsEmail) GetQueryParams() (map[string]string, error) {
+	return getQueryParams(s)
 }
 
 // Group is a Group
@@ -209,7 +210,12 @@ type GetGroupsParams struct {
 	BaseParams
 	First  int    `json:"first,string,omitempty"`
 	Max    int    `json:"max,string,omitempty"`
-	Search string `json:"search,string,omitempty"`
+	Search string `json:"search,omitempty"`
+}
+
+// GetQueryParams converts the struct to map[string]string
+func (s GetGroupsParams) GetQueryParams() (map[string]string, error) {
+	return getQueryParams(s)
 }
 
 // Role is a role
@@ -282,8 +288,13 @@ type Client struct {
 // GetClientsParams represents the query parameters
 type GetClientsParams struct {
 	BaseParams
-	ClientID     string `json:"clientId,string,omitempty"`
+	ClientID     string `json:"clientId,omitempty"`
 	ViewableOnly bool   `json:"viewableOnly,string,omitempty"`
+}
+
+// GetQueryParams converts the struct to map[string]string
+func (s GetClientsParams) GetQueryParams() (map[string]string, error) {
+	return getQueryParams(s)
 }
 
 // UserInfo is returned by the userinfo endpoint


### PR DESCRIPTION
Thanks for your contribution!
Hi, if there is an issue, that your PR adresses, please link it! 

Preventing the string from including double quotes, in values of the string type.

GetQueryParams in BaseParams returns nil map. 