### PR TITLE
Decode expired tokens

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -3,6 +3,7 @@ package gocloak
 import (
 	"crypto/tls"
 	"encoding/json"
+	"github.com/dgrijalva/jwt-go"
 	"gopkg.in/resty.v1"
 	"io/ioutil"
 	"math/rand"
@@ -16,8 +17,6 @@ import (
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/Nerzal/gocloak/pkg/jwx"
 )
 
 type configAdmin struct {
@@ -401,19 +400,18 @@ func TestGocloak_DecodeAccessToken(t *testing.T) {
 }
 
 func TestGocloak_DecodeAccessTokenCustomClaims(t *testing.T) {
-	t.Skipf(
-		"Due to error: %s",
-		"DecodeAccessTokenCustomClaims: json: cannot unmarshal object into Go value of type jwt.Claims")
 	t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClient(cfg.HostName)
 	token := GetClientToken(t, client)
 
-	claims := jwx.Claims{}
-	_, err := client.DecodeAccessTokenCustomClaims(
+	claims := jwt.MapClaims{}
+	resultToken, err := client.DecodeAccessTokenCustomClaims(
 		token.AccessToken,
 		cfg.GoCloak.Realm,
 		claims)
+	t.Log(resultToken)
+	t.Log(claims)
 	FailIfErr(t, err, "DecodeAccessTokenCustomClaims")
 }
 

--- a/pkg/jwx/jwx.go
+++ b/pkg/jwx/jwx.go
@@ -79,11 +79,8 @@ func DecodeAccessToken(accessToken string, e string, n string) (*jwt.Token, *jwt
 		}
 		return rsaPublicKey, nil
 	})
-	if err != nil {
-		return nil, nil, err
-	}
 
-	return token2, claims, nil
+	return token2, claims, err
 }
 
 // DecodeAccessTokenCustomClaims currently only supports RSA - sorry for that
@@ -100,11 +97,8 @@ func DecodeAccessTokenCustomClaims(accessToken string, e string, n string, custo
 		}
 		return rsaPublicKey, nil
 	})
-	if err != nil {
-		return nil, err
-	}
 
-	return token2, nil
+	return token2, err
 }
 
 func getRSAPublicKey(publicKey string) (*rsa.PublicKey, error) {


### PR DESCRIPTION
To be able to decode expired tokens the DecodeAccessToken and
DecodeAccessTokenCustomClaims functions should return token anyway.

We need to be able to decode a token regardless of whether it is expired or not.