### PR TITLE
Allow basic querying for events

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ type GoCloak interface {
 	GetRealm(token string, realm string) (*RealmRepresentation, error)
 	CreateRealm(token string, realm RealmRepresentation) error
 	DeleteRealm(token string, realm string) error
+
+	// *** Events ***
+	GetEvents(accessToken string, realm string, params *GetEventsParams) ([]EventRepresentation, error)
 }
 ```
 

--- a/client.go
+++ b/client.go
@@ -962,3 +962,27 @@ func (client *gocloak) DeleteUserFromGroup(token string, realm string, userID st
 
 	return checkForError(resp, err)
 }
+
+// GetEvents get all events in a realm
+func (client *gocloak) GetEvents(token string, realm string, params *GetEventsParams) ([]EventRepresentation, error) {
+	var result []EventRepresentation
+	queryParams, err := GetQueryParams(params)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.getRequestWithBearerAuth(token).
+		SetResult(&result).
+		SetQueryParams(queryParams).
+		Get(client.getAdminRealmURL(realm, "events"))
+
+	if err := checkForError(resp, err); err != nil {
+		return nil, err
+	}
+
+	for i := range result {
+		result[i].GoTime = time.Unix(result[i].Time/1000, (result[i].Time%1000)*1000000)
+	}
+
+	return result, nil
+}

--- a/client_test.go
+++ b/client_test.go
@@ -1283,3 +1283,30 @@ func TestGocloak_GetUsersByRoleName(t *testing.T) {
 		userID,
 		(*users)[0].ID)
 }
+
+// -----------
+// Events
+// -----------
+
+func GetEvents(t *testing.T, client GoCloak, cfg *Config) (func()) {
+	token := GetAdminToken(t, client)
+
+	tearDown := func() {
+		events, err := client.GetEvents(
+			token.AccessToken,
+			cfg.GoCloak.Realm,
+			&GetEventsParams{})
+		FailIfErr(t, err, "GetEvents failed")
+		FailIf(t, len(events) != 0, "no events expected")
+	}
+	return tearDown
+}
+
+func TestGocloak_GetEvents(t *testing.T) {
+	t.Parallel()
+	cfg := GetConfig(t)
+	client := NewClient(cfg.HostName)
+	tearDown := GetEvents(t, client, cfg)
+	defer tearDown()
+
+}

--- a/gocloak.go
+++ b/gocloak.go
@@ -152,4 +152,7 @@ type GoCloak interface {
 	AddUserToGroup(token string, realm string, userID string, groupID string) error
 	// DeleteUserFromGroup deletes given user from given group
 	DeleteUserFromGroup(token string, realm string, userID string, groupID string) error
+
+	// *** Events ***
+	GetEvents(accessToken string, realm string, params *GetEventsParams) ([]EventRepresentation, error)
 }

--- a/models.go
+++ b/models.go
@@ -1,6 +1,7 @@
 package gocloak
 
 import "encoding/json"
+import "time"
 
 // GetQueryParams converts the struct to map[string]string
 // The fields tags must have `json:"<name>,string,omitempty"` format for all types, except strings
@@ -395,4 +396,31 @@ type CredentialRepresentation struct {
 	Temporary         bool               `json:"temporary,omitempty"`
 	Type              string             `json:"type,omitempty"`
 	Value             string             `json:"value,omitempty"`
+}
+
+// GetEventsParams represents the optional parameters for getting events
+type GetEventsParams struct {
+	Type      string `json:"Type,omitempty"`
+	Client    string `json:"client,omitempty"`
+	User      string `json:"user,omitempty"`
+	DateFrom  string `json:"dateFrom,omitempty"`
+	DateTo    string `json:"dateTo,omitempty"`
+	IPAddress string `json:"ipAddress,omitempty"`
+	First     int    `json:"first,string,omitempty"`
+	Max       int    `json:"max,string,omitempty"`
+	Realm     string `json:"realm"`
+}
+
+// EventRepresentation represent a event
+type EventRepresentation struct {
+	Time      int64             `json:"time,omitempty"`
+	GoTime    time.Time         `json:"-"`
+	Type      string            `json:"type,omitempty"`
+	RealmID   string            `json:"realmID,omitempty"`
+	ClientID  string            `json:"clientID,omitempty"`
+	UserID    string            `json:"userID,omitempty"`
+	SessionID string            `json:"sessionID,omitempty"`
+	IPAddress string            `json:"ipAddress,omitempty"`
+	Error     string            `json:"error,omitempty"`
+	Details   map[string]string `json:"details,omitempty"`
 }


### PR DESCRIPTION
This PR adds support for events querying as described here: https://www.keycloak.org/docs-api/2.5/rest-api/index.html#_get_events