### PR TITLE
Add omitempty flag to ID field of ClientRepresentation model

### DIFF
--- a/models.go
+++ b/models.go
@@ -278,7 +278,7 @@ type Client struct {
 	Enabled                            bool                           `json:"enabled,omitempty"`
 	FrontChannelLogout                 bool                           `json:"frontChannelLogout,omitempty"`
 	FullScopeAllowed                   bool                           `json:"fullScopeAllowed,omitempty"`
-	ID                                 string                         `json:"id"`
+	ID                                 string                         `json:"id,omitempty"`
 	ImplicitFlowEnabled                bool                           `json:"implicitFlowEnabled,omitempty"`
 	Name                               string                         `json:"name,omitempty"`
 	NodeReRegistrationTimeout          int32                          `json:"nodeReRegistrationTimeout,omitempty"`


### PR DESCRIPTION
Fix #55
Partialy-Fix: #31 

Rewrite the CreateClient unit tests for sure, that all client functions work as expected:
    * CreateClient - creates a client without the ID parameter
    * GetClients with ClientID as a search parameter returns exact client
    * GetClient returns the same client
    * DeleteClient deletes the client
