### PR TITLE
Refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,25 @@ https://gopkg.in/nerzal/gocloak.v1
 
 ## Usage
 
+### Importing
+
+Since the version 3 you need to import the gocloak library using v3 suffix:
+
+```go
+	import "github.com/Nerzal/gocloak/v3"
+```
+
+#### Version 2:
+
+```go
+	go get gopkg.in/nerzal/gocloak@v2.1.0
+```
+
+```go
+	import "github.com/Nerzal/gocloak"
+```
+
+
 ### Create New User
 ```go
 	client := gocloak.NewClient("https://mycool.keycloak.instance")

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ type GoCloak interface {
 	SetPassword(token string, userID string, realm string, password string, temporary bool) error
 	ExecuteActionsEmail(token string, realm string, params ExecuteActionsEmail) error
 
-	CreateUser(token string, realm string, user User) (*string, error)
+	CreateUser(token string, realm string, user User) (string, error)
 	CreateGroup(accessToken string, realm string, group Group) error
 	CreateClientRole(accessToken string, realm string, clientID string, role Role) error
 	CreateClient(accessToken string, realm string, clientID Client) error
@@ -121,26 +121,26 @@ type GoCloak interface {
 	GetKeyStoreConfig(accessToken string, realm string) (*KeyStoreConfig, error)
 	GetUserByID(accessToken string, realm string, userID string) (*User, error)
 	GetUserCount(accessToken string, realm string) (int, error)
-	GetUsers(accessToken string, realm string, params GetUsersParams) (*[]User, error)
-	GetUserGroups(accessToken string, realm string, userID string) (*[]UserGroup, error)
-	GetComponents(accessToken string, realm string) (*[]Component, error)
-	GetGroups(accessToken string, realm string, params GetGroupsParams) (*[]Group, error)
+	GetUsers(accessToken string, realm string, params GetUsersParams) ([]*User, error)
+	GetUserGroups(accessToken string, realm string, userID string) ([]*UserGroup, error)
+	GetComponents(accessToken string, realm string) ([]*Component, error)
+	GetGroups(accessToken string, realm string, params GetGroupsParams) ([]*Group, error)
 	GetGroup(accessToken string, realm, groupID string) (*Group, error)
 	GetRoleMappingByGroupID(accessToken string, realm string, groupID string) (*MappingsRepresentation, error)
 	GetRoleMappingByUserID(accessToken string, realm string, userID string) (*MappingsRepresentation, error)
-	GetClientRoles(accessToken string, realm string, clientID string) (*[]Role, error)
+	GetClientRoles(accessToken string, realm string, clientID string) ([]*Role, error)
 	GetClientRole(token string, realm string, clientID string, roleName string) (*Role, error)
-	GetClients(accessToken string, realm string, params GetClientsParams) (*[]Client, error)
-	GetUsersByRoleName(token string, realm string, roleName string) (*[]User, error)
+	GetClients(accessToken string, realm string, params GetClientsParams) ([]*Client, error)
+	GetUsersByRoleName(token string, realm string, roleName string) ([]*User, error)
 	UserAttributeContains(attributes map[string][]string, attribute string, value string) bool
 
 	// *** Realm Roles ***
 
 	CreateRealmRole(token string, realm string, role Role) error
 	GetRealmRole(token string, realm string, roleName string) (*Role, error)
-	GetRealmRoles(accessToken string, realm string) (*[]Role, error)
-	GetRealmRolesByUserID(accessToken string, realm string, userID string) (*[]Role, error)
-	GetRealmRolesByGroupID(accessToken string, realm string, groupID string) (*[]Role, error)
+	GetRealmRoles(accessToken string, realm string) ([]*Role, error)
+	GetRealmRolesByUserID(accessToken string, realm string, userID string) ([]*Role, error)
+	GetRealmRolesByGroupID(accessToken string, realm string, groupID string) ([]*Role, error)
 	UpdateRealmRole(token string, realm string, roleName string, role Role) error
 	DeleteRealmRole(token string, realm string, roleName string) error
 	AddRealmRoleToUser(token string, realm string, userID string, roles []Role) error
@@ -154,10 +154,10 @@ type GoCloak interface {
 	CreateRealm(token string, realm RealmRepresentation) error
 	DeleteRealm(token string, realm string) error
 
-	GetClientUserSessions(token, realm, clientID string) (*[]UserSessionRepresentation, error)
-	GetClientOfflineSessions(token, realm, clientID string) (*[]UserSessionRepresentation, error)
-	GetUserSessions(token, realm, userID string) (*[]UserSessionRepresentation, error)
-	GetUserOfflineSessionsForClient(token, realm, userID, clientID string) (*[]UserSessionRepresentation, error)
+	GetClientUserSessions(token, realm, clientID string) ([]*UserSessionRepresentation, error)
+	GetClientOfflineSessions(token, realm, clientID string) ([]*UserSessionRepresentation, error)
+	GetUserSessions(token, realm, userID string) ([]*UserSessionRepresentation, error)
+	GetUserOfflineSessionsForClient(token, realm, userID, clientID string) ([]*UserSessionRepresentation, error)
 }
 ```
 

--- a/client.go
+++ b/client.go
@@ -487,8 +487,8 @@ func (client *gocloak) GetClientSecret(token string, realm string, clientID stri
 }
 
 // GetClientOfflineSessions returns offline sessions associated with the client
-func (client *gocloak) GetClientOfflineSessions(token, realm, clientID string) (*[]UserSessionRepresentation, error) {
-	var res []UserSessionRepresentation
+func (client *gocloak) GetClientOfflineSessions(token, realm, clientID string) ([]*UserSessionRepresentation, error) {
+	var res []*UserSessionRepresentation
 	resp, err := client.getRequestWithBearerAuth(token).
 		SetResult(&res).
 		Get(client.getAdminRealmURL(realm, "clients", clientID, "offline-sessions"))
@@ -496,12 +496,12 @@ func (client *gocloak) GetClientOfflineSessions(token, realm, clientID string) (
 	if err := checkForError(resp, err); err != nil {
 		return nil, err
 	}
-	return &res, nil
+	return res, nil
 }
 
 // GetClientUserSessions returns user sessions associated with the client
-func (client *gocloak) GetClientUserSessions(token, realm, clientID string) (*[]UserSessionRepresentation, error) {
-	var res []UserSessionRepresentation
+func (client *gocloak) GetClientUserSessions(token, realm, clientID string) ([]*UserSessionRepresentation, error) {
+	var res []*UserSessionRepresentation
 	resp, err := client.getRequestWithBearerAuth(token).
 		SetResult(&res).
 		Get(client.getAdminRealmURL(realm, "clients", clientID, "user-sessions"))
@@ -509,7 +509,7 @@ func (client *gocloak) GetClientUserSessions(token, realm, clientID string) (*[]
 	if err := checkForError(resp, err); err != nil {
 		return nil, err
 	}
-	return &res, nil
+	return res, nil
 }
 
 // GetKeyStoreConfig get keystoreconfig of the realm
@@ -527,8 +527,8 @@ func (client *gocloak) GetKeyStoreConfig(token string, realm string) (*KeyStoreC
 }
 
 // GetComponents get all components in realm
-func (client *gocloak) GetComponents(token string, realm string) (*[]Component, error) {
-	var result []Component
+func (client *gocloak) GetComponents(token string, realm string) ([]*Component, error) {
+	var result []*Component
 	resp, err := client.getRequestWithBearerAuth(token).
 		SetResult(&result).
 		Get(client.getAdminRealmURL(realm, "components"))
@@ -537,7 +537,7 @@ func (client *gocloak) GetComponents(token string, realm string) (*[]Component, 
 		return nil, err
 	}
 
-	return &result, nil
+	return result, nil
 }
 
 func (client *gocloak) getRoleMappings(token string, realm string, path string, objectID string) (*MappingsRepresentation, error) {
@@ -578,8 +578,8 @@ func (client *gocloak) GetGroup(token string, realm string, groupID string) (*Gr
 }
 
 // GetGroups get all groups in realm
-func (client *gocloak) GetGroups(token string, realm string, params GetGroupsParams) (*[]Group, error) {
-	var result []Group
+func (client *gocloak) GetGroups(token string, realm string, params GetGroupsParams) ([]*Group, error) {
+	var result []*Group
 	queryParams, err := GetQueryParams(params)
 	if err != nil {
 		return nil, err
@@ -594,12 +594,12 @@ func (client *gocloak) GetGroups(token string, realm string, params GetGroupsPar
 		return nil, err
 	}
 
-	return &result, nil
+	return result, nil
 }
 
 // GetClientRoles get all roles for the given client in realm
-func (client *gocloak) GetClientRoles(token string, realm string, clientID string) (*[]Role, error) {
-	var result []Role
+func (client *gocloak) GetClientRoles(token string, realm string, clientID string) ([]*Role, error) {
+	var result []*Role
 	resp, err := client.getRequestWithBearerAuth(token).
 		SetResult(&result).
 		Get(client.getAdminRealmURL(realm, "clients", clientID, "roles"))
@@ -608,7 +608,7 @@ func (client *gocloak) GetClientRoles(token string, realm string, clientID strin
 		return nil, err
 	}
 
-	return &result, nil
+	return result, nil
 }
 
 // GetClientRole get a role for the given client in a realm by role name
@@ -626,8 +626,8 @@ func (client *gocloak) GetClientRole(token string, realm string, clientID string
 }
 
 // GetClients gets all clients in realm
-func (client *gocloak) GetClients(token string, realm string, params GetClientsParams) (*[]Client, error) {
-	var result []Client
+func (client *gocloak) GetClients(token string, realm string, params GetClientsParams) ([]*Client, error) {
+	var result []*Client
 	queryParams, err := GetQueryParams(params)
 	if err != nil {
 		return nil, err
@@ -641,7 +641,7 @@ func (client *gocloak) GetClients(token string, realm string, params GetClientsP
 		return nil, err
 	}
 
-	return &result, nil
+	return result, nil
 }
 
 // UserAttributeContains checks if the given attribute value is set
@@ -684,8 +684,8 @@ func (client *gocloak) GetRealmRole(token string, realm string, roleName string)
 }
 
 // GetRealmRoles get all roles of the given realm.
-func (client *gocloak) GetRealmRoles(token string, realm string) (*[]Role, error) {
-	var result []Role
+func (client *gocloak) GetRealmRoles(token string, realm string) ([]*Role, error) {
+	var result []*Role
 	resp, err := client.getRequestWithBearerAuth(token).
 		SetResult(&result).
 		Get(client.getAdminRealmURL(realm, "roles"))
@@ -694,12 +694,12 @@ func (client *gocloak) GetRealmRoles(token string, realm string) (*[]Role, error
 		return nil, err
 	}
 
-	return &result, nil
+	return result, nil
 }
 
 // GetRealmRolesByUserID returns all roles assigned to the given user
-func (client *gocloak) GetRealmRolesByUserID(token string, realm string, userID string) (*[]Role, error) {
-	var result []Role
+func (client *gocloak) GetRealmRolesByUserID(token string, realm string, userID string) ([]*Role, error) {
+	var result []*Role
 	resp, err := client.getRequestWithBearerAuth(token).
 		SetResult(&result).
 		Get(client.getAdminRealmURL(realm, "users", userID, "role-mappings", "realm"))
@@ -708,12 +708,12 @@ func (client *gocloak) GetRealmRolesByUserID(token string, realm string, userID 
 		return nil, err
 	}
 
-	return &result, nil
+	return result, nil
 }
 
 // GetRealmRolesByGroupID returns all roles assigned to the given group
-func (client *gocloak) GetRealmRolesByGroupID(token string, realm string, groupID string) (*[]Role, error) {
-	var result []Role
+func (client *gocloak) GetRealmRolesByGroupID(token string, realm string, groupID string) ([]*Role, error) {
+	var result []*Role
 	resp, err := client.getRequestWithBearerAuth(token).
 		Get(client.getAdminRealmURL(realm, "groups", groupID, "role-mappings", "realm"))
 
@@ -721,7 +721,7 @@ func (client *gocloak) GetRealmRolesByGroupID(token string, realm string, groupI
 		return nil, err
 	}
 
-	return &result, nil
+	return result, nil
 }
 
 // UpdateRealmRole updates a role in a realm
@@ -814,20 +814,20 @@ func (client *gocloak) DeleteRealm(token string, realm string) error {
 // -----
 
 // CreateUser creates the given user in the given realm and returns it's userID
-func (client *gocloak) CreateUser(token string, realm string, user User) (*string, error) {
+func (client *gocloak) CreateUser(token string, realm string, user User) (string, error) {
 	resp, err := client.getRequestWithBearerAuth(token).
 		SetBody(user).
 		Post(client.getAdminRealmURL(realm, "users"))
 
 	if err := checkForError(resp, err); err != nil {
-		return nil, err
+		return "", err
 	}
 
 	userPath := resp.Header().Get("Location")
 	splittedPath := strings.Split(userPath, urlSeparator)
 	userID := splittedPath[len(splittedPath)-1]
 
-	return &userID, nil
+	return userID, nil
 }
 
 // DeleteUser delete a given user
@@ -871,8 +871,8 @@ func (client *gocloak) GetUserCount(token string, realm string) (int, error) {
 }
 
 // GetUserGroups get all groups for user
-func (client *gocloak) GetUserGroups(token string, realm string, userID string) (*[]UserGroup, error) {
-	var result []UserGroup
+func (client *gocloak) GetUserGroups(token string, realm string, userID string) ([]*UserGroup, error) {
+	var result []*UserGroup
 	resp, err := client.getRequestWithBearerAuth(token).
 		SetResult(&result).
 		Get(client.getAdminRealmURL(realm, "users", userID, "groups"))
@@ -881,12 +881,12 @@ func (client *gocloak) GetUserGroups(token string, realm string, userID string) 
 		return nil, err
 	}
 
-	return &result, nil
+	return result, nil
 }
 
 // GetUsers get all users in realm
-func (client *gocloak) GetUsers(token string, realm string, params GetUsersParams) (*[]User, error) {
-	var result []User
+func (client *gocloak) GetUsers(token string, realm string, params GetUsersParams) ([]*User, error) {
+	var result []*User
 	queryParams, err := GetQueryParams(params)
 	if err != nil {
 		return nil, err
@@ -901,12 +901,12 @@ func (client *gocloak) GetUsers(token string, realm string, params GetUsersParam
 		return nil, err
 	}
 
-	return &result, nil
+	return result, nil
 }
 
 // GetUsersByRoleName returns all users have a given role
-func (client *gocloak) GetUsersByRoleName(token string, realm string, roleName string) (*[]User, error) {
-	var result []User
+func (client *gocloak) GetUsersByRoleName(token string, realm string, roleName string) ([]*User, error) {
+	var result []*User
 	resp, err := client.getRequestWithBearerAuth(token).
 		SetResult(&result).
 		Get(client.getAdminRealmURL(realm, "roles", roleName, "users"))
@@ -915,7 +915,7 @@ func (client *gocloak) GetUsersByRoleName(token string, realm string, roleName s
 		return nil, err
 	}
 
-	return &result, nil
+	return result, nil
 }
 
 // SetPassword sets a new password for the user with the given id. Needs elevated privileges
@@ -954,8 +954,8 @@ func (client *gocloak) DeleteUserFromGroup(token string, realm string, userID st
 }
 
 // GetUserSessions returns user sessions associated with the user
-func (client *gocloak) GetUserSessions(token, realm, userID string) (*[]UserSessionRepresentation, error) {
-	var res []UserSessionRepresentation
+func (client *gocloak) GetUserSessions(token, realm, userID string) ([]*UserSessionRepresentation, error) {
+	var res []*UserSessionRepresentation
 	resp, err := client.getRequestWithBearerAuth(token).
 		SetResult(&res).
 		Get(client.getAdminRealmURL(realm, "users", userID, "sessions"))
@@ -963,12 +963,12 @@ func (client *gocloak) GetUserSessions(token, realm, userID string) (*[]UserSess
 	if err := checkForError(resp, err); err != nil {
 		return nil, err
 	}
-	return &res, nil
+	return res, nil
 }
 
 // GetUserOfflineSessionsForClient returns offline sessions associated with the user and client
-func (client *gocloak) GetUserOfflineSessionsForClient(token, realm, userID, clientID string) (*[]UserSessionRepresentation, error) {
-	var res []UserSessionRepresentation
+func (client *gocloak) GetUserOfflineSessionsForClient(token, realm, userID, clientID string) ([]*UserSessionRepresentation, error) {
+	var res []*UserSessionRepresentation
 	resp, err := client.getRequestWithBearerAuth(token).
 		SetResult(&res).
 		Get(client.getAdminRealmURL(realm, "users", userID, "offline-sessions", clientID))
@@ -976,5 +976,5 @@ func (client *gocloak) GetUserOfflineSessionsForClient(token, realm, userID, cli
 	if err := checkForError(resp, err); err != nil {
 		return nil, err
 	}
-	return &res, nil
+	return res, nil
 }

--- a/client.go
+++ b/client.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Nerzal/gocloak/pkg/jwx"
+	"github.com/Nerzal/gocloak/v3/pkg/jwx"
 	"github.com/dgrijalva/jwt-go"
 	"gopkg.in/resty.v1"
 )

--- a/client_test.go
+++ b/client_test.go
@@ -162,9 +162,9 @@ func GetClientByClientID(t *testing.T, client GoCloak, clientID string) *Client 
 			ClientID: clientID,
 		})
 	FailIfErr(t, err, "GetClients failed")
-	for _, fetchedClient := range *clients {
+	for _, fetchedClient := range clients {
 		if fetchedClient.ClientID == clientID {
-			return &fetchedClient
+			return fetchedClient
 		}
 	}
 	t.Fatal("Client not found")
@@ -190,7 +190,7 @@ func CreateGroup(t *testing.T, client GoCloak) (func(), string) {
 		})
 	FailIfErr(t, err, "GetGroups failed")
 	var groupID string
-	for _, fetchedGroup := range *groups {
+	for _, fetchedGroup := range groups {
 		if fetchedGroup.Name == group.Name {
 			groupID = fetchedGroup.ID
 			break
@@ -233,7 +233,7 @@ func SetUpTestUser(t *testing.T, client GoCloak) {
 					Username: cfg.GoCloak.UserName,
 				})
 			FailIfErr(t, err, "GetUsers failed")
-			for _, user := range *users {
+			for _, user := range users {
 				if user.Username == cfg.GoCloak.UserName {
 					testUserID = user.ID
 					break
@@ -241,7 +241,7 @@ func SetUpTestUser(t *testing.T, client GoCloak) {
 			}
 		} else {
 			FailIfErr(t, err, "CreateUser failed")
-			testUserID = *createdUserID
+			testUserID = createdUserID
 		}
 
 		err = client.SetPassword(
@@ -704,19 +704,19 @@ func TestGocloak_CreateListGetUpdateDeleteClient(t *testing.T) {
 		},
 	)
 	FailIfErr(t, err, "CreateClients failed")
-	FailIf(t, len(*clients) != 1, "GetClients should return exact 1 client")
-	t.Logf("Clients: %+v", *clients)
+	FailIf(t, len(clients) != 1, "GetClients should return exact 1 client")
+	t.Logf("Clients: %+v", clients)
 
 	// Getting exact client
 	createdClient, err := client.GetClient(
 		token.AccessToken,
 		cfg.GoCloak.Realm,
-		(*clients)[0].ID,
+		clients[0].ID,
 	)
 	FailIfErr(t, err, "GetClient failed")
 	t.Logf("Created client: %+v", createdClient)
 	// Checking that GetClient returns same client
-	AssertEquals(t, (*clients)[0], *createdClient)
+	AssertEquals(t, clients[0], createdClient)
 
 	// Updating the client
 
@@ -741,7 +741,7 @@ func TestGocloak_CreateListGetUpdateDeleteClient(t *testing.T) {
 	updatedClient, err := client.GetClient(
 		token.AccessToken,
 		cfg.GoCloak.Realm,
-		(*clients)[0].ID,
+		clients[0].ID,
 	)
 	FailIfErr(t, err, "GetClient failed")
 	t.Logf("Update client: %+v", createdClient)
@@ -764,7 +764,7 @@ func TestGocloak_CreateListGetUpdateDeleteClient(t *testing.T) {
 		},
 	)
 	FailIfErr(t, err, "CreateClients failed")
-	FailIf(t, len(*clients) != 0, "GetClients should not return any clients")
+	FailIf(t, len(clients) != 0, "GetClients should not return any clients")
 
 }
 
@@ -999,7 +999,7 @@ func TestGocloak_GetRealmRoles(t *testing.T) {
 		token.AccessToken,
 		cfg.GoCloak.Realm)
 	FailIfErr(t, err, "GetRealmRoles failed")
-	t.Logf("Roles: %+v", *roles)
+	t.Logf("Roles: %+v", roles)
 }
 
 func TestGocloak_UpdateRealmRole(t *testing.T) {
@@ -1106,8 +1106,8 @@ func TestGocloak_GetRealmRolesByUserID(t *testing.T) {
 		cfg.GoCloak.Realm,
 		userID)
 	FailIfErr(t, err, "GetRealmRolesByUserID failed")
-	t.Logf("User roles: %+v", *roles)
-	for _, r := range *roles {
+	t.Logf("User roles: %+v", roles)
+	for _, r := range roles {
 		if r.Name == role.Name {
 			return
 		}
@@ -1169,11 +1169,11 @@ func TestGocloak_DeleteRealmRoleFromUser(t *testing.T) {
 		cfg.GoCloak.Realm,
 		userID)
 	FailIfErr(t, err, "GetRealmRolesByUserID failed")
-	for _, r := range *roles {
+	for _, r := range roles {
 		FailIf(
 			t,
 			r.Name == role.Name,
-			"The role has been found in asigned roles. Role: %+v", role)
+			"The role has been found in assigned roles. Role: %+v", role)
 	}
 }
 
@@ -1246,7 +1246,7 @@ func CreateUser(t *testing.T, client GoCloak) (func(), string) {
 		cfg.GoCloak.Realm,
 		user)
 	FailIfErr(t, err, "CreateUser failed")
-	user.ID = *userID
+	user.ID = userID
 	t.Logf("Created User: %+v", user)
 	tearDown := func() {
 		err := client.DeleteUser(
@@ -1405,12 +1405,12 @@ func TestGocloak_GetUserGroups(t *testing.T) {
 	FailIfErr(t, err, "GetUserGroups failed")
 	FailIf(
 		t,
-		len(*groups) == 0,
+		len(groups) == 0,
 		"User is not in the Group")
 	AssertEquals(
 		t,
 		groupID,
-		(*groups)[0].ID)
+		groups[0].ID)
 }
 
 func TestGocloak_DeleteUser(t *testing.T) {
@@ -1476,12 +1476,12 @@ func TestGocloak_GetUsersByRoleName(t *testing.T) {
 
 	FailIf(
 		t,
-		len(*users) == 0,
+		len(users) == 0,
 		"User is not in the Group")
 	AssertEquals(
 		t,
 		userID,
-		(*users)[0].ID)
+		users[0].ID)
 }
 
 func TestGocloak_GetUserSessions(t *testing.T) {
@@ -1507,7 +1507,7 @@ func TestGocloak_GetUserSessions(t *testing.T) {
 		testUserID,
 	)
 	FailIfErr(t, err, "GetUserSessions failed")
-	FailIf(t, len(*sessions) == 0, "GetUserSessions returned an empty list")
+	FailIf(t, len(sessions) == 0, "GetUserSessions returned an empty list")
 }
 
 func TestGocloak_GetUserOfflineSessionsForClient(t *testing.T) {
@@ -1536,7 +1536,7 @@ func TestGocloak_GetUserOfflineSessionsForClient(t *testing.T) {
 		gocloakClientID,
 	)
 	FailIfErr(t, err, "GetUserOfflineSessionsForClient failed")
-	FailIf(t, len(*sessions) == 0, "GetUserOfflineSessionsForClient returned an empty list")
+	FailIf(t, len(sessions) == 0, "GetUserOfflineSessionsForClient returned an empty list")
 }
 
 func TestGocloak_GetClientUserSessions(t *testing.T) {
@@ -1562,7 +1562,7 @@ func TestGocloak_GetClientUserSessions(t *testing.T) {
 		gocloakClientID,
 	)
 	FailIfErr(t, err, "GetClientUserSessions failed")
-	FailIf(t, len(*sessions) == 0, "GetClientUserSessions returned an empty list")
+	FailIf(t, len(sessions) == 0, "GetClientUserSessions returned an empty list")
 }
 
 func TestGocloak_GetClientOfflineSessions(t *testing.T) {
@@ -1590,5 +1590,5 @@ func TestGocloak_GetClientOfflineSessions(t *testing.T) {
 		gocloakClientID,
 	)
 	FailIfErr(t, err, "GetClientOfflineSessions failed")
-	FailIf(t, len(*sessions) == 0, "GetClientOfflineSessions returned an empty list")
+	FailIf(t, len(sessions) == 0, "GetClientOfflineSessions returned an empty list")
 }

--- a/errors.go
+++ b/errors.go
@@ -1,8 +1,21 @@
 package gocloak
 
 // ObjectAlreadyExists is used when keycloak answers with 409
-type ObjectAlreadyExists struct{}
+type ObjectAlreadyExists struct {
+	ErrorMessage string
+}
 
-func (o *ObjectAlreadyExists) Error() string {
-	return "Conflict: Object already exists"
+func (e *ObjectAlreadyExists) Error() string {
+	return e.ErrorMessage
+}
+
+// IsObjectAlreadyExists is a helper to verify tht the err is ObjectAlreadyExists
+func IsObjectAlreadyExists(err error) bool {
+	_, ok := err.(*ObjectAlreadyExists)
+	return ok
+}
+
+// HTTPErrorResponse is a model of an error response
+type HTTPErrorResponse struct {
+	ErrorMessage string `json:"errorMessage,omitempty"`
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Nerzal/gocloak
+module github.com/Nerzal/gocloak/v3
 
 require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible

--- a/gocloak.go
+++ b/gocloak.go
@@ -80,9 +80,9 @@ type GoCloak interface {
 	// GetKeyStoreConfig gets the keyStoreConfig
 	GetKeyStoreConfig(accessToken string, realm string) (*KeyStoreConfig, error)
 	// GetComponents gets components of the given realm
-	GetComponents(accessToken string, realm string) (*[]Component, error)
+	GetComponents(accessToken string, realm string) ([]*Component, error)
 	// GetGroups gets all groups of the given realm
-	GetGroups(accessToken string, realm string, params GetGroupsParams) (*[]Group, error)
+	GetGroups(accessToken string, realm string, params GetGroupsParams) ([]*Group, error)
 	// GetGroup gets the given group
 	GetGroup(accessToken string, realm, groupID string) (*Group, error)
 	// GetRoleMappingByGroupID gets the rolemapping for the given group id
@@ -90,15 +90,15 @@ type GoCloak interface {
 	// GetRoleMappingByUserID gets the rolemapping for the given user id
 	GetRoleMappingByUserID(accessToken string, realm string, userID string) (*MappingsRepresentation, error)
 	// GetClientRoles gets roles for the given client
-	GetClientRoles(accessToken string, realm string, clientID string) (*[]Role, error)
+	GetClientRoles(accessToken string, realm string, clientID string) ([]*Role, error)
 	// GetClientRole get a role for the given client in a realm by role name
 	GetClientRole(token string, realm string, clientID string, roleName string) (*Role, error)
 	// GetClients gets the clients in the realm
-	GetClients(accessToken string, realm string, params GetClientsParams) (*[]Client, error)
+	GetClients(accessToken string, realm string, params GetClientsParams) ([]*Client, error)
 	// GetClientOfflineSessions returns offline sessions associated with the client
-	GetClientOfflineSessions(token, realm, clientID string) (*[]UserSessionRepresentation, error)
+	GetClientOfflineSessions(token, realm, clientID string) ([]*UserSessionRepresentation, error)
 	// GetClientUserSessions returns user sessions associated with the client
-	GetClientUserSessions(token, realm, clientID string) (*[]UserSessionRepresentation, error)
+	GetClientUserSessions(token, realm, clientID string) ([]*UserSessionRepresentation, error)
 
 	// UserAttributeContains checks if the given attribute has the given value
 	UserAttributeContains(attributes map[string][]string, attribute string, value string) bool
@@ -110,11 +110,11 @@ type GoCloak interface {
 	// GetRealmRole returns a role from a realm by role's name
 	GetRealmRole(token string, realm string, roleName string) (*Role, error)
 	// GetRealmRoles get all roles of the given realm. It's an alias for the GetRoles function
-	GetRealmRoles(accessToken string, realm string) (*[]Role, error)
+	GetRealmRoles(accessToken string, realm string) ([]*Role, error)
 	// GetRealmRolesByUserID returns all roles assigned to the given user
-	GetRealmRolesByUserID(accessToken string, realm string, userID string) (*[]Role, error)
+	GetRealmRolesByUserID(accessToken string, realm string, userID string) ([]*Role, error)
 	// GetRealmRolesByGroupID returns all roles assigned to the given group
-	GetRealmRolesByGroupID(accessToken string, realm string, groupID string) (*[]Role, error)
+	GetRealmRolesByGroupID(accessToken string, realm string, groupID string) ([]*Role, error)
 	// UpdateRealmRole updates a role in a realm
 	UpdateRealmRole(token string, realm string, roleName string, role Role) error
 	// DeleteRealmRole deletes a role in a realm by role's name
@@ -139,7 +139,7 @@ type GoCloak interface {
 
 	// *** Users ***
 	// CreateUser creates a new user
-	CreateUser(token string, realm string, user User) (*string, error)
+	CreateUser(token string, realm string, user User) (string, error)
 	// DeleteUser deletes the given user
 	DeleteUser(accessToken string, realm, userID string) error
 	// GetUserByID gets the user with the given id
@@ -147,11 +147,11 @@ type GoCloak interface {
 	// GetUser count returns the userCount of the given realm
 	GetUserCount(accessToken string, realm string) (int, error)
 	// GetUsers gets all users of the given realm
-	GetUsers(accessToken string, realm string, params GetUsersParams) (*[]User, error)
+	GetUsers(accessToken string, realm string, params GetUsersParams) ([]*User, error)
 	// GetUserGroups gets the groups of the given user
-	GetUserGroups(accessToken string, realm string, userID string) (*[]UserGroup, error)
+	GetUserGroups(accessToken string, realm string, userID string) ([]*UserGroup, error)
 	// GetUsersByRoleName returns all users have a given role
-	GetUsersByRoleName(token string, realm string, roleName string) (*[]User, error)
+	GetUsersByRoleName(token string, realm string, roleName string) ([]*User, error)
 	// SetPassword sets a new password for the user with the given id. Needs elevated privileges
 	SetPassword(token string, userID string, realm string, password string, temporary bool) error
 	// UpdateUser updates the given user
@@ -161,7 +161,7 @@ type GoCloak interface {
 	// DeleteUserFromGroup deletes given user from given group
 	DeleteUserFromGroup(token string, realm string, userID string, groupID string) error
 	// GetUserSessions returns user sessions associated with the user
-	GetUserSessions(token, realm, userID string) (*[]UserSessionRepresentation, error)
+	GetUserSessions(token, realm, userID string) ([]*UserSessionRepresentation, error)
 	// GetUserOfflineSessionsForClient returns offline sessions associated with the user and client
-	GetUserOfflineSessionsForClient(token, realm, userID, clientID string) (*[]UserSessionRepresentation, error)
+	GetUserOfflineSessionsForClient(token, realm, userID, clientID string) ([]*UserSessionRepresentation, error)
 }

--- a/models.go
+++ b/models.go
@@ -66,7 +66,7 @@ type RetrospecTokenResult struct {
 	Nbf         int               `json:"nbf,omitempty"`
 	Iat         int               `json:"iat,omitempty"`
 	Aud         string            `json:"aud,omitempty"`
-	Active      bool              `json:"active,omitempty"`
+	Active      bool              `json:"active"`
 	AuthTime    int               `json:"auth_time,omitempty"`
 	Jti         string            `json:"jti,omitempty"`
 	Type        string            `json:"typ,omitempty"`
@@ -77,9 +77,9 @@ type User struct {
 	ID                         string              `json:"id,omitempty"`
 	CreatedTimestamp           int64               `json:"createdTimestamp,omitempty"`
 	Username                   string              `json:"username,omitempty"`
-	Enabled                    bool                `json:"enabled,omitempty"`
-	Totp                       bool                `json:"totp,omitempty"`
-	EmailVerified              bool                `json:"emailVerified,omitempty"`
+	Enabled                    bool                `json:"enabled"`
+	Totp                       bool                `json:"totp"`
+	EmailVerified              bool                `json:"emailVerified"`
 	FirstName                  string              `json:"firstName,omitempty"`
 	LastName                   string              `json:"lastName,omitempty"`
 	Email                      string              `json:"email,omitempty"`
@@ -87,13 +87,13 @@ type User struct {
 	Attributes                 map[string][]string `json:"attributes,omitempty"`
 	DisableableCredentialTypes []interface{}       `json:"disableableCredentialTypes,omitempty"`
 	RequiredActions            []interface{}       `json:"requiredActions,omitempty"`
-	Access                     map[string]bool     `json:"access,omitempty"`
+	Access                     map[string]bool     `json:"access"`
 }
 
 // SetPasswordRequest sets a new password
 type SetPasswordRequest struct {
 	Type      string `json:"type,omitempty"`
-	Temporary bool   `json:"temporary,omitempty"`
+	Temporary bool   `json:"temporary"`
 	Password  string `json:"value,omitempty"`
 }
 
@@ -147,11 +147,11 @@ type Attributes struct {
 
 // Access represents access
 type Access struct {
-	ManageGroupMembership bool `json:"manageGroupMembership,omitempty"`
-	View                  bool `json:"view,omitempty"`
-	MapRoles              bool `json:"mapRoles,omitempty"`
-	Impersonate           bool `json:"impersonate,omitempty"`
-	Manage                bool `json:"manage,omitempty"`
+	ManageGroupMembership bool `json:"manageGroupMembership"`
+	View                  bool `json:"view"`
+	MapRoles              bool `json:"mapRoles"`
+	Impersonate           bool `json:"impersonate"`
+	Manage                bool `json:"manage"`
 }
 
 // UserGroup is a UserGroup
@@ -163,7 +163,7 @@ type UserGroup struct {
 
 // GetUsersParams represents the optional parameters for getting users
 type GetUsersParams struct {
-	BriefRepresentation *bool  `json:"briefRepresentation,string,omitempty"`
+	BriefRepresentation bool   `json:"briefRepresentation,string"`
 	Email               string `json:"email,omitempty"`
 	First               int    `json:"first,string,omitempty"`
 	FirstName           string `json:"firstName,omitempty"`
@@ -201,9 +201,9 @@ type GetGroupsParams struct {
 type Role struct {
 	ID                 string              `json:"id,omitempty"`
 	Name               string              `json:"name,omitempty"`
-	ScopeParamRequired bool                `json:"scopeParamRequired,omitempty"`
-	Composite          bool                `json:"composite,omitempty"`
-	ClientRole         bool                `json:"clientRole,omitempty"`
+	ScopeParamRequired bool                `json:"scopeParamRequired"`
+	Composite          bool                `json:"composite"`
+	ClientRole         bool                `json:"clientRole"`
 	ContainerID        string              `json:"containerId,omitempty"`
 	Description        string              `json:"description,omitempty"`
 	Attributes         map[string][]string `json:"attributes,omitempty"`
@@ -245,7 +245,7 @@ type ProtocolMappers struct {
 	Name                  string                `json:"name,omitempty"`
 	Protocol              string                `json:"protocol,omitempty"`
 	ProtocolMapper        string                `json:"protocolMapper,omitempty"`
-	ConsentRequired       bool                  `json:"consentRequired,omitempty"`
+	ConsentRequired       bool                  `json:"consentRequired"`
 	ProtocolMappersConfig ProtocolMappersConfig `json:"config,omitempty"`
 }
 
@@ -266,22 +266,22 @@ type Client struct {
 	AdminURL                           string                         `json:"adminUrl,omitempty"`
 	Attributes                         map[string]string              `json:"attributes,omitempty"`
 	AuthenticationFlowBindingOverrides map[string]string              `json:"authenticationFlowBindingOverrides,omitempty"`
-	AuthorizationServicesEnabled       bool                           `json:"authorizationServicesEnabled,omitempty"`
+	AuthorizationServicesEnabled       bool                           `json:"authorizationServicesEnabled"`
 	AuthorizationSettings              *ResourceServerRepresentation  `json:"authorizationSettings,omitempty"`
 	BaseURL                            string                         `json:"baseURL,omitempty"`
-	BearerOnly                         bool                           `json:"bearerOnly,omitempty"`
+	BearerOnly                         bool                           `json:"bearerOnly"`
 	ClientAuthenticatorType            string                         `json:"clientAuthenticatorType,omitempty"`
 	ClientID                           string                         `json:"clientId,omitempty"`
-	ConsentRequired                    bool                           `json:"consentRequired,omitempty"`
+	ConsentRequired                    bool                           `json:"consentRequired"`
 	DefaultClientScopes                []string                       `json:"defaultClientScopes,omitempty"`
 	DefaultRoles                       []string                       `json:"defaultRoles,omitempty"`
 	Description                        string                         `json:"description,omitempty"`
-	DirectAccessGrantsEnabled          bool                           `json:"directAccessGrantsEnabled,omitempty"`
-	Enabled                            bool                           `json:"enabled,omitempty"`
-	FrontChannelLogout                 bool                           `json:"frontchannelLogout,omitempty"`
-	FullScopeAllowed                   bool                           `json:"fullScopeAllowed,omitempty"`
+	DirectAccessGrantsEnabled          bool                           `json:"directAccessGrantsEnabled"`
+	Enabled                            bool                           `json:"enabled"`
+	FrontChannelLogout                 bool                           `json:"frontchannelLogout"`
+	FullScopeAllowed                   bool                           `json:"fullScopeAllowed"`
 	ID                                 string                         `json:"id,omitempty"`
-	ImplicitFlowEnabled                bool                           `json:"implicitFlowEnabled,omitempty"`
+	ImplicitFlowEnabled                bool                           `json:"implicitFlowEnabled"`
 	Name                               string                         `json:"name,omitempty"`
 	NodeReRegistrationTimeout          int32                          `json:"nodeReRegistrationTimeout,omitempty"`
 	NotBefore                          int32                          `json:"notBefore,omitempty"`
@@ -289,21 +289,21 @@ type Client struct {
 	Origin                             string                         `json:"origin,omitempty"`
 	Protocol                           string                         `json:"protocol,omitempty"`
 	ProtocolMappers                    []ProtocolMapperRepresentation `json:"protocolMappers,omitempty"`
-	PublicClient                       bool                           `json:"publicClient,omitempty"`
+	PublicClient                       bool                           `json:"publicClient"`
 	RedirectURIs                       []string                       `json:"redirectUris,omitempty"`
 	RegisteredNodes                    map[string]string              `json:"registeredNodes,omitempty"`
 	RegistrationAccessToken            string                         `json:"registrationAccessToken,omitempty"`
 	RootURL                            string                         `json:"rootUrl,omitempty"`
 	Secret                             string                         `json:"secret,omitempty"`
-	ServiceAccountsEnabled             bool                           `json:"serviceAccountsEnabled,omitempty"`
-	StandardFlowEnabled                bool                           `json:"standardFlowEnabled,omitempty"`
-	SurrogateAuthRequired              bool                           `json:"surrogateAuthRequired,omitempty"`
+	ServiceAccountsEnabled             bool                           `json:"serviceAccountsEnabled"`
+	StandardFlowEnabled                bool                           `json:"standardFlowEnabled"`
+	SurrogateAuthRequired              bool                           `json:"surrogateAuthRequired"`
 	WebOrigins                         []string                       `json:"webOrigins,omitempty"`
 }
 
 // ResourceServerRepresentation represents the resources of a Server
 type ResourceServerRepresentation struct {
-	AllowRemoteResourceManagement bool                     `json:"allowRemoteResourceManagement,omitempty"`
+	AllowRemoteResourceManagement bool                     `json:"allowRemoteResourceManagement"`
 	ClientID                      string                   `json:"clientId,omitempty"`
 	ID                            string                   `json:"id,omitempty"`
 	Name                          string                   `json:"name,omitempty"`
@@ -364,7 +364,7 @@ type ResourceRepresentation struct {
 	DisplayName        string                `json:"displayName,omitempty"`
 	IconURI            string                `json:"icon_uri,omitempty"` //TODO: With "_" because that's how it's written down in the template
 	Name               string                `json:"name,omitempty"`
-	OwnerManagedAccess bool                  `json:"ownerManagedAccess,omitempty"`
+	OwnerManagedAccess bool                  `json:"ownerManagedAccess"`
 	Scopes             []ScopeRepresentation `json:"scopes,omitempty"`
 	Type               string                `json:"type,omitempty"`
 	URIs               []string              `json:"uris,omitempty"`
@@ -392,13 +392,13 @@ type ProtocolMapperRepresentation struct {
 // GetClientsParams represents the query parameters
 type GetClientsParams struct {
 	ClientID     string `json:"clientId,omitempty"`
-	ViewableOnly bool   `json:"viewableOnly,string,omitempty"`
+	ViewableOnly bool   `json:"viewableOnly,string"`
 }
 
 // UserInfo is returned by the userinfo endpoint
 type UserInfo struct {
 	Sub               string      `json:"sub,omitempty"`
-	EmailVerified     bool        `json:"email_verified,omitempty"`
+	EmailVerified     bool        `json:"email_verified"`
 	Address           interface{} `json:"address,omitempty"`
 	PreferredUsername string      `json:"preferred_username,omitempty"`
 	Email             string      `json:"email,omitempty"`
@@ -414,15 +414,15 @@ type RealmRepresentation struct {
 	AccountTheme                        string            `json:"accountTheme,omitempty"`
 	ActionTokenGeneratedByAdminLifespan int               `json:"actionTokenGeneratedByAdminLifespan,omitempty"`
 	ActionTokenGeneratedByUserLifespan  int               `json:"actionTokenGeneratedByUserLifespan,omitempty"`
-	AdminEventsDetailsEnabled           bool              `json:"adminEventsDetailsEnabled,omitempty"`
-	AdminEventsEnabled                  bool              `json:"adminEventsEnabled,omitempty"`
+	AdminEventsDetailsEnabled           bool              `json:"adminEventsDetailsEnabled"`
+	AdminEventsEnabled                  bool              `json:"adminEventsEnabled"`
 	AdminTheme                          string            `json:"adminTheme,omitempty"`
 	Attributes                          map[string]string `json:"attributes,omitempty"`
 	AuthenticationFlows                 []interface{}     `json:"authenticationFlows,omitempty"`
 	AuthenticatorConfig                 []interface{}     `json:"authenticatorConfig,omitempty"`
 	BrowserFlow                         string            `json:"browserFlow,omitempty"`
 	BrowserSecurityHeaders              map[string]string `json:"browserSecurityHeaders,omitempty"`
-	BruteForceProtected                 bool              `json:"bruteForceProtected,omitempty"`
+	BruteForceProtected                 bool              `json:"bruteForceProtected"`
 	ClientAuthenticationFlow            string            `json:"clientAuthenticationFlow,omitempty"`
 	ClientScopeMappings                 map[string]string `json:"clientScopeMappings,omitempty"`
 	ClientScopes                        []ClientScope     `json:"clientScopes,omitempty"`
@@ -438,12 +438,12 @@ type RealmRepresentation struct {
 	DisplayName                         string            `json:"displayName,omitempty"`
 	DisplayNameHTML                     string            `json:"displayNameHtml,omitempty"`
 	DockerAuthenticationFlow            string            `json:"dockerAuthenticationFlow,omitempty"`
-	DuplicateEmailsAllowed              bool              `json:"duplicateEmailsAllowed,omitempty"`
-	EditUsernameAllowed                 bool              `json:"editUsernameAllowed,omitempty"`
+	DuplicateEmailsAllowed              bool              `json:"duplicateEmailsAllowed"`
+	EditUsernameAllowed                 bool              `json:"editUsernameAllowed"`
 	EmailTheme                          string            `json:"emailTheme,omitempty"`
-	Enabled                             bool              `json:"enabled,omitempty"`
+	Enabled                             bool              `json:"enabled"`
 	EnabledEventTypes                   []string          `json:"enabledEventTypes,omitempty"`
-	EventsEnabled                       bool              `json:"eventsEnabled,omitempty"`
+	EventsEnabled                       bool              `json:"eventsEnabled"`
 	EventsExpiration                    int64             `json:"eventsExpiration,omitempty"`
 	EventsListeners                     []string          `json:"eventsListeners,omitempty"`
 	FailureFactor                       int               `json:"failureFactor,omitempty"`
@@ -452,17 +452,17 @@ type RealmRepresentation struct {
 	ID                                  string            `json:"id,omitempty"`
 	IdentityProviderMappers             []interface{}     `json:"identityProviderMappers,omitempty"`
 	IdentityProviders                   []interface{}     `json:"identityProviders,omitempty"`
-	InternationalizationEnabled         bool              `json:"internationalizationEnabled,omitempty"`
+	InternationalizationEnabled         bool              `json:"internationalizationEnabled"`
 	KeycloakVersion                     string            `json:"keycloakVersion,omitempty"`
 	LoginTheme                          string            `json:"loginTheme,omitempty"`
-	LoginWithEmailAllowed               bool              `json:"loginWithEmailAllowed,omitempty"`
+	LoginWithEmailAllowed               bool              `json:"loginWithEmailAllowed"`
 	MaxDeltaTimeSeconds                 int               `json:"maxDeltaTimeSeconds,omitempty"`
 	MaxFailureWaitSeconds               int               `json:"maxFailureWaitSeconds,omitempty"`
 	MinimumQuickLoginWaitSeconds        int               `json:"minimumQuickLoginWaitSeconds,omitempty"`
 	NotBefore                           int               `json:"notBefore,omitempty"`
 	OfflineSessionIdleTimeout           int               `json:"offlineSessionIdleTimeout,omitempty"`
 	OfflineSessionMaxLifespan           int               `json:"offlineSessionMaxLifespan,omitempty"`
-	OfflineSessionMaxLifespanEnabled    bool              `json:"offlineSessionMaxLifespanEnabled,omitempty"`
+	OfflineSessionMaxLifespanEnabled    bool              `json:"offlineSessionMaxLifespanEnabled"`
 	OtpPolicyAlgorithm                  string            `json:"otpPolicyAlgorithm,omitempty"`
 	OtpPolicyDigits                     int               `json:"otpPolicyDigits,omitempty"`
 	OtpPolicyInitialCounter             int               `json:"otpPolicyInitialCounter,omitempty"`
@@ -471,19 +471,19 @@ type RealmRepresentation struct {
 	OtpPolicyType                       string            `json:"otpPolicyType,omitempty"`
 	OtpSupportedApplications            []string          `json:"otpSupportedApplications,omitempty"`
 	PasswordPolicy                      string            `json:"passwordPolicy,omitempty"`
-	PermanentLockout                    bool              `json:"permanentLockout,omitempty"`
+	PermanentLockout                    bool              `json:"permanentLockout"`
 	ProtocolMappers                     []interface{}     `json:"protocolMappers,omitempty"`
 	QuickLoginCheckMilliSeconds         int64             `json:"quickLoginCheckMilliSeconds,omitempty"`
 	Realm                               string            `json:"realm,omitempty"`
 	RefreshTokenMaxReuse                int               `json:"refreshTokenMaxReuse,omitempty"`
-	RegistrationAllowed                 bool              `json:"registrationAllowed,omitempty"`
-	RegistrationEmailAsUsername         bool              `json:"registrationEmailAsUsername,omitempty"`
+	RegistrationAllowed                 bool              `json:"registrationAllowed"`
+	RegistrationEmailAsUsername         bool              `json:"registrationEmailAsUsername"`
 	RegistrationFlow                    string            `json:"registrationFlow,omitempty"`
-	RememberMe                          bool              `json:"rememberMe,omitempty"`
+	RememberMe                          bool              `json:"rememberMe"`
 	RequiredActions                     []interface{}     `json:"requiredActions,omitempty"`
 	ResetCredentialsFlow                string            `json:"resetCredentialsFlow,omitempty"`
-	ResetPasswordAllowed                bool              `json:"resetPasswordAllowed,omitempty"`
-	RevokeRefreshToken                  bool              `json:"revokeRefreshToken,omitempty"`
+	ResetPasswordAllowed                bool              `json:"resetPasswordAllowed"`
+	RevokeRefreshToken                  bool              `json:"revokeRefreshToken"`
 	Roles                               interface{}       `json:"roles,omitempty"`
 	ScopeMappings                       []interface{}     `json:"scopeMappings,omitempty"`
 	SMTPServer                          map[string]string `json:"smtpServer,omitempty"`
@@ -495,15 +495,15 @@ type RealmRepresentation struct {
 	SupportedLocales                    []string          `json:"supportedLocales,omitempty"`
 	UserFederationMappers               []interface{}     `json:"userFederationMappers,omitempty"`
 	UserFederationProviders             []interface{}     `json:"userFederationProviders,omitempty"`
-	UserManagedAccessAllowed            bool              `json:"userManagedAccessAllowed,omitempty"`
+	UserManagedAccessAllowed            bool              `json:"userManagedAccessAllowed"`
 	Users                               []interface{}     `json:"users,omitempty"`
-	VerifyEmail                         bool              `json:"verifyEmail,omitempty"`
+	VerifyEmail                         bool              `json:"verifyEmail"`
 	WaitIncrementSeconds                int               `json:"waitIncrementSeconds,omitempty"`
 }
 
 // MultivaluedHashMap represents something
 type MultivaluedHashMap struct {
-	Empty      bool    `json:"empty,omitempty"`
+	Empty      bool    `json:"empty"`
 	LoadFactor float32 `json:"loadFactor,omitempty"`
 	Threshold  int32   `json:"threshold,omitempty"`
 }
@@ -520,7 +520,7 @@ type CredentialRepresentation struct {
 	HashedSaltedValue string             `json:"hashedSaltedValue,omitempty"`
 	Period            int32              `json:"period,omitempty"`
 	Salt              string             `json:"salt,omitempty"`
-	Temporary         bool               `json:"temporary,omitempty"`
+	Temporary         bool               `json:"temporary"`
 	Type              string             `json:"type,omitempty"`
 	Value             string             `json:"value,omitempty"`
 }

--- a/tools/bump_version.go
+++ b/tools/bump_version.go
@@ -195,9 +195,12 @@ func main() {
 
 		if *major {
 			newTag.Major += 1
+			newTag.Minor = 0
+			newTag.Patch = 0
 		}
 		if *minor || (!*major && !*patch) {
 			newTag.Minor += 1
+			newTag.Patch = 0
 		}
 		if *patch {
 			newTag.Patch += 1


### PR DESCRIPTION
1. Return list of pointers to the objects instead of pointer to a list of the objects
Change return types of several function to return `[]*<type>` instead of `*[]<type>`.
Fix unit tests.
Also the `CreateUser` function now returns `string` instead of `*string`.

2. Using Resty `SetError` method to get the Keycloak's error message
Add a hellep `IsObjectAlreadyExists` to verify that an error is ObjectAlreadyExists

3. Remove omitempty for all bool parameters

4. Using v3 suffix to support go.mod semantic versions
Update README.md with an information how to install and use versions 2 and 3

4. Fix bump_version tool
In case of increasing major version the minor and patch versions keeps the old values,
and the same thing happens with increasing minor version, the patch version keeps the old value.