### PR TITLE
Fix golint and add go vet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ branches:
 stages:
   - style
   - test
+  - goreportcard
+
 
 jobs:
   include:
@@ -19,7 +21,9 @@ jobs:
       script: diff -u <(echo -n) <(gofmt -d -s .)
     - name: "golint"
       install: go get -u golang.org/x/lint/golint
-      script: golint -set_exit_status
+      script: golint -set_exit_status ./...
+    - name: "govet"
+      script: go vet ./...
     - stage: test
       before_install:
         - docker pull jboss/keycloak
@@ -31,3 +35,6 @@ jobs:
       after_failure:
         - docker ps
         - docker logs keycloak
+    - stage: goreportcard
+      script: curl --fail --request POST "https://goreportcard.com/checks" --data "repo=github.com/Nerzal/gocloak"
+      if: branch = master AND type = push

--- a/models.go
+++ b/models.go
@@ -175,11 +175,11 @@ type GetUsersParams struct {
 
 // ExecuteActionsEmail represents parameters for executing action emails
 type ExecuteActionsEmail struct {
-	UserID      string   `json:"-,omitempty"`
+	UserID      string   `json:"-"`
 	ClientID    string   `json:"client_id,omitempty"`
 	Lifespan    int      `json:"lifespan,string,omitempty"`
 	RedirectURI string   `json:"redirect_uri,omitempty"`
-	Actions     []string `json:"-,omitempty"`
+	Actions     []string `json:"-"`
 }
 
 // Group is a Group

--- a/tools/bump_version.go
+++ b/tools/bump_version.go
@@ -12,16 +12,19 @@ import (
 	"strings"
 )
 
+// Version is a structure to represent a version
 type Version struct {
 	Major int
 	Minor int
 	Patch int
 }
 
+// String returns a string representation of version
 func (v *Version) String() string {
 	return fmt.Sprintf("v%d.%d.%d", v.Major, v.Minor, v.Patch)
 }
 
+// Parse converts a string representation of version
 func (v *Version) Parse(raw string) bool {
 	v.Major = 0
 	v.Minor = 0
@@ -56,6 +59,7 @@ func (v *Version) Parse(raw string) bool {
 	return true
 }
 
+// Less compares the v with another
 func (v *Version) Less(another *Version) bool {
 	return v.Major < another.Major || v.Minor < another.Minor || v.Patch < another.Patch
 }
@@ -194,16 +198,16 @@ func main() {
 		newTag = lastTag
 
 		if *major {
-			newTag.Major += 1
+			newTag.Major++
 			newTag.Minor = 0
 			newTag.Patch = 0
 		}
 		if *minor || (!*major && !*patch) {
-			newTag.Minor += 1
+			newTag.Minor++
 			newTag.Patch = 0
 		}
 		if *patch {
-			newTag.Patch += 1
+			newTag.Patch++
 		}
 	}
 	changeLog := getChangeLog(lastTag)


### PR DESCRIPTION
The `golint` command was configured incorrectly, because of what the full check is not performed.
Execute the `go vet` command.

Re-generate gorepordcard for commits in master branch.

Fix style according to the reports of golint and go vet.
