### PR TITLE
Adding method to regenerate a client secret using the Keycloak API

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ type GoCloak interface {
 
 	GetClient(accessToken string, realm string, clientID string) (*Client, error)
 	GetClientSecret(token string, realm string, clientID string) (*CredentialRepresentation, error)
+	RegenerateClientSecret(token string, realm string, clientID string) (*CredentialRepresentation, error)
 	GetKeyStoreConfig(accessToken string, realm string) (*KeyStoreConfig, error)
 	GetUserByID(accessToken string, realm string, userID string) (*User, error)
 	GetUserCount(accessToken string, realm string) (int, error)

--- a/client.go
+++ b/client.go
@@ -499,6 +499,18 @@ func (client *gocloak) GetClientSecret(token string, realm string, clientID stri
 	return &result, nil
 }
 
+func (client *gocloak) RegenerateClientSecret(token string, realm string, clientID string) (*CredentialRepresentation, error) {
+	var result CredentialRepresentation
+	resp, err := client.getRequestWithBearerAuth(token).
+		SetResult(&result).
+		Post(client.getAdminRealmURL(realm, "clients", clientID, "client-secret"))
+
+		if err := checkForError(resp, err); err != nil {
+			return nil, err
+		}
+	return &result, nil
+}
+
 // GetClientOfflineSessions returns offline sessions associated with the client
 func (client *gocloak) GetClientOfflineSessions(token, realm, clientID string) ([]*UserSessionRepresentation, error) {
 	var res []*UserSessionRepresentation

--- a/client.go
+++ b/client.go
@@ -505,9 +505,9 @@ func (client *gocloak) RegenerateClientSecret(token string, realm string, client
 		SetResult(&result).
 		Post(client.getAdminRealmURL(realm, "clients", clientID, "client-secret"))
 
-		if err := checkForError(resp, err); err != nil {
-			return nil, err
-		}
+	if err := checkForError(resp, err); err != nil {
+		return nil, err
+	}
 	return &result, nil
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -1654,7 +1654,25 @@ func TestGoCloak_ClientSecret(t *testing.T) {
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
 
-	testClient := GetClientByClientID(t, client, "gocloak-client-secret")
+	testClient := Client{
+		ID:                      "2262b302-b4d4-47d4-89d1-b7a3313368ec",
+		ClientID:                "gocloak-client-secret",
+		Secret:                  "initial-secret-key",
+		ServiceAccountsEnabled:  true,
+		StandardFlowEnabled:     true,
+		Enabled:                 true,
+		FullScopeAllowed:        true,
+		Protocol:                "openid-connect",
+		RedirectURIs:            []string{"localhost"},
+		ClientAuthenticatorType: "client-secret",
+	}
+
+	err := client.CreateClient(
+		token.AccessToken,
+		cfg.GoCloak.Realm,
+		testClient,
+	)
+	FailIfErr(t, err, "CreateClient failed")
 
 	oldCreds, err := client.GetClientSecret(
 		token.AccessToken,

--- a/gocloak.go
+++ b/gocloak.go
@@ -77,6 +77,8 @@ type GoCloak interface {
 	GetClient(accessToken string, realm string, clientID string) (*Client, error)
 	// GetClientSecret returns a client's secret
 	GetClientSecret(token string, realm string, clientID string) (*CredentialRepresentation, error)
+	// RegenerateClientSecret creates a new client secret returning the updated CredentialRepresentation
+	RegenerateClientSecret(token string, realm string, clientID string) (*CredentialRepresentation, error)
 	// GetKeyStoreConfig gets the keyStoreConfig
 	GetKeyStoreConfig(accessToken string, realm string) (*KeyStoreConfig, error)
 	// GetComponents gets components of the given realm

--- a/testdata/gocloak-realm.json
+++ b/testdata/gocloak-realm.json
@@ -290,59 +290,6 @@
       ]
     },
     {
-      "id": "e25afdcb-bbfe-428a-aeb6-11a44dde0efd",
-      "clientId": "gocloak-client-secret",
-      "surrogateAuthRequired": false,
-      "enabled": true,
-      "clientAuthenticatorType": "client-secret",
-      "secret": "gocloak-secret",
-      "redirectUris": [
-        "localhost"
-      ],
-      "webOrigins": [],
-      "notBefore": 0,
-      "bearerOnly": false,
-      "consentRequired": false,
-      "standardFlowEnabled": true,
-      "implicitFlowEnabled": false,
-      "directAccessGrantsEnabled": true,
-      "serviceAccountsEnabled": true,
-      "publicClient": false,
-      "frontchannelLogout": false,
-      "protocol": "openid-connect",
-      "attributes": {
-        "saml.assertion.signature": "false",
-        "saml.force.post.binding": "false",
-        "saml.multivalued.roles": "false",
-        "saml.encrypt": "false",
-        "saml.server.signature": "false",
-        "saml.server.signature.keyinfo.ext": "false",
-        "exclude.session.state.from.auth.response": "false",
-        "saml_force_name_id_format": "false",
-        "saml.client.signature": "false",
-        "tls.client.certificate.bound.access.tokens": "false",
-        "saml.authnstatement": "false",
-        "display.on.consent.screen": "false",
-        "saml.onetimeuse.condition": "false"
-      },
-      "authenticationFlowBindingOverrides": {},
-      "fullScopeAllowed": true,
-      "nodeReRegistrationTimeout": -1,
-      "protocolMappers": [],
-      "defaultClientScopes": [
-        "web-origins",
-        "role_list",
-        "profile",
-        "roles",
-        "email"
-      ],
-      "optionalClientScopes": [
-        "address",
-        "phone",
-        "offline_access"
-      ]
-    },
-    {
       "id": "db4d47d3-31cd-49c7-a1c7-351e13da7907",
       "clientId": "realm-management",
       "name": "${client_realm-management}",

--- a/testdata/gocloak-realm.json
+++ b/testdata/gocloak-realm.json
@@ -290,6 +290,59 @@
       ]
     },
     {
+      "id": "e25afdcb-bbfe-428a-aeb6-11a44dde0efd",
+      "clientId": "gocloak-client-secret",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "gocloak-secret",
+      "redirectUris": [
+        "localhost"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.force.post.binding": "false",
+        "saml.multivalued.roles": "false",
+        "saml.encrypt": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "exclude.session.state.from.auth.response": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "saml.authnstatement": "false",
+        "display.on.consent.screen": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [],
+      "defaultClientScopes": [
+        "web-origins",
+        "role_list",
+        "profile",
+        "roles",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access"
+      ]
+    },
+    {
       "id": "db4d47d3-31cd-49c7-a1c7-351e13da7907",
       "clientId": "realm-management",
       "name": "${client_realm-management}",


### PR DESCRIPTION
Adds Client secret regeneration as described in issue #82 .

Tests pass, documentation and interface updated. 

Fix #82 