### PR TITLE
Fix json struct tag for Client's BaseURL field

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -959,6 +959,7 @@ func TestGocloak_CreateListGetUpdateDeleteClient(t *testing.T) {
 		Client{
 			ClientID: clientID,
 			Name:     GetRandomName("Name"),
+			BaseURL:  "http://example.com",
 		},
 	)
 	FailIfErr(t, err, "CreateClient failed")

--- a/models.go
+++ b/models.go
@@ -275,7 +275,7 @@ type Client struct {
 	AuthenticationFlowBindingOverrides map[string]string              `json:"authenticationFlowBindingOverrides,omitempty"`
 	AuthorizationServicesEnabled       bool                           `json:"authorizationServicesEnabled"`
 	AuthorizationSettings              *ResourceServerRepresentation  `json:"authorizationSettings,omitempty"`
-	BaseURL                            string                         `json:"baseURL,omitempty"`
+	BaseURL                            string                         `json:"baseUrl,omitempty"`
 	BearerOnly                         bool                           `json:"bearerOnly"`
 	ClientAuthenticatorType            string                         `json:"clientAuthenticatorType,omitempty"`
 	ClientID                           string                         `json:"clientId,omitempty"`


### PR DESCRIPTION
The Keycloak REST API specifies the client representation's base URL field as "baseUrl". https://www.keycloak.org/docs-api/5.0/rest-api/index.html#_clientrepresentation. 

Unfortunately this leads to a 400 Bad Request if you specify the baseURL in the Client struct when creating a client. This can be reproduced in the tests by adding a value for the field baseURL for the Client created in this test: https://github.com/Nerzal/gocloak/blob/master/client_test.go#L959. 

This PR simply changes "baseURL" -> "baseUrl". 