### PR TITLE
set user agent

### DIFF
--- a/client.go
+++ b/client.go
@@ -101,6 +101,11 @@ func NewClient(basePath string) GoCloak {
 		certsCache:  make(map[string]*CertResponse),
 		restyClient: resty.New(),
 	}
+
+	c.restyClient.SetHeaders(map[string]string{
+		"User-Agent": "gocloak/" + Version + " go-resty/" + resty.Version,
+	})
+
 	c.Config.CertsInvalidateTime = 10 * time.Minute
 
 	return &c

--- a/gocloak.go
+++ b/gocloak.go
@@ -5,6 +5,10 @@ import (
 	"gopkg.in/resty.v1"
 )
 
+// Version number of gocloak
+// exported so implementations can include the version number in debug output
+const Version = "3.5.1"
+
 // GoCloak holds all methods a client should fulfill
 type GoCloak interface {
 	// RestyClient returns a resty client that gocloak uses


### PR DESCRIPTION
in order to identify calls from this library, set the user agent to 

"gocloak/3.5.1 go-resty/2.0.0"

where the resty version is being taken from the resty version field and the gocloak version from a newly introduced version field