### PR TITLE
Add full group representation

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -1144,7 +1144,7 @@ func TestGocloak_GetGroupsFull(t *testing.T) {
 		}
 	}
 
-	assert.Fail(t, "CreateGroup failed")
+	assert.Fail(t, "GetGroupsFull failed")
 }
 
 func TestGocloak_GetGroupFull(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -1128,6 +1128,34 @@ func TestGocloak_GetGroupsFull(t *testing.T) {
 	tearDown, groupID := CreateGroup(t, client)
 	defer tearDown()
 
+	groups, err := client.GetGroups(
+		token.AccessToken,
+		cfg.GoCloak.Realm,
+		GetGroupsParams{
+			Full: true,
+		})
+	assert.NoError(t, err, "GetGroups failed")
+
+	for _, group := range groups {
+		if group.ID == groupID {
+			ok := client.UserAttributeContains(group.Attributes, "foo", "alice")
+			assert.True(t, ok, "UserAttributeContains")
+			return
+		}
+	}
+
+	assert.Fail(t, "CreateGroup failed")
+}
+
+func TestGocloak_GetGroupFull(t *testing.T) {
+	t.Parallel()
+	cfg := GetConfig(t)
+	client := NewClientWithDebug(t)
+	token := GetAdminToken(t, client)
+
+	tearDown, groupID := CreateGroup(t, client)
+	defer tearDown()
+
 	createdGroup, err := client.GetGroup(
 		token.AccessToken,
 		cfg.GoCloak.Realm,

--- a/client_test.go
+++ b/client_test.go
@@ -209,7 +209,8 @@ func CreateGroup(t *testing.T, client GoCloak) (func(), string) {
 	group := Group{
 		Name: GetRandomName("GroupName"),
 		Attributes: map[string][]string{
-			"hello": []string{"world"},
+			"foo": {"bar", "alice", "bob", "roflcopter"},
+			"bar": {"baz"},
 		},
 	}
 	err := client.CreateGroup(
@@ -1134,7 +1135,7 @@ func TestGocloak_GetGroupsFull(t *testing.T) {
 	)
 	assert.NoError(t, err, "GetGroup failed")
 
-	ok := client.UserAttributeContains(createdGroup.Attributes, "hello", "world")
+	ok := client.UserAttributeContains(createdGroup.Attributes, "foo", "alice")
 	assert.True(t, ok, "UserAttributeContains")
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -1138,6 +1138,40 @@ func TestGocloak_GetGroupsFull(t *testing.T) {
 	assert.True(t, ok, "UserAttributeContains")
 }
 
+func TestGocloak_GetGroupMembers(t *testing.T) {
+	t.Parallel()
+	cfg := GetConfig(t)
+	client := NewClientWithDebug(t)
+	token := GetAdminToken(t, client)
+	tearDownUser, userID := CreateUser(t, client)
+	defer tearDownUser()
+
+	tearDownGroup, groupID := CreateGroup(t, client)
+	defer tearDownGroup()
+
+	err := client.AddUserToGroup(
+		token.AccessToken,
+		cfg.GoCloak.Realm,
+		userID,
+		groupID,
+	)
+	assert.NoError(t, err, "AddUserToGroup failed")
+
+	users, err := client.GetGroupMembers(
+		token.AccessToken,
+		cfg.GoCloak.Realm,
+		groupID,
+		GetGroupsParams{},
+	)
+	assert.NoError(t, err, "AddUserToGroup failed")
+
+	assert.Equal(
+		t,
+		1,
+		len(users),
+	)
+}
+
 func TestGocloak_GetClientRoles(t *testing.T) {
 	t.Parallel()
 	cfg := GetConfig(t)

--- a/models.go
+++ b/models.go
@@ -218,10 +218,14 @@ type ExecuteActionsEmail struct {
 
 // Group is a Group
 type Group struct {
-	ID        string        `json:"id,omitempty"`
-	Name      string        `json:"name,omitempty"`
-	Path      string        `json:"path,omitempty"`
-	SubGroups []interface{} `json:"subGroups,omitempty"`
+	ID          string              `json:"id,omitempty"`
+	Name        string              `json:"name,omitempty"`
+	Path        string              `json:"path,omitempty"`
+	SubGroups   []*Group            `json:"subGroups,omitempty"`
+	Attributes  map[string][]string `json:"attributes,emitempty"`
+	Access      map[string]bool     `json:"access,omitempty"`
+	ClientRoles map[string][]string `json:"clientRoles,omitempty"`
+	RealmRoles  []string            `json:"realmRoles,omitempty"`
 }
 
 // GetGroupsParams represents the optional parameters for getting groups
@@ -229,6 +233,7 @@ type GetGroupsParams struct {
 	First  int    `json:"first,string,omitempty"`
 	Max    int    `json:"max,string,omitempty"`
 	Search string `json:"search,omitempty"`
+	Full   bool   `json:"full,string,omitempty"`
 }
 
 // Role is a role


### PR DESCRIPTION
I'd like to be able to get all of the fields of a group. The naming of `UserAttributeContains` seems a bit off now because both user and groups attributes are the same. However, changing it would cause an API change.
