### PR TITLE
Properly returning permission data when introspecting rpt

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -742,6 +742,9 @@ func TestGocloak_GetRequestingPartyToken(t *testing.T) {
 	)
 	assert.NoError(t, err, "Get requesting party token failed")
 	t.Logf("New RPT: %+v", *rpt)
+
+	_, err = client.RetrospectToken(rpt.AccessToken, cfg.GoCloak.ClientID, cfg.GoCloak.ClientSecret, cfg.GoCloak.Realm)
+	assert.NoError(t, err, "RetrospectToken failed")
 }
 
 func TestGocloak_LoginClient(t *testing.T) {

--- a/models.go
+++ b/models.go
@@ -89,17 +89,25 @@ type IssuerResponse struct {
 	TokensNotBefore *int    `json:"tokens-not-before,omitempty"`
 }
 
+// ResourcePermission represents a permission granted to a resource
+type ResourcePermission struct {
+	RSID           *string  `json:"rsid"`
+	RSName         *string  `json:"rsname,omitempty"`
+	Scopes         []string `json:"scopes,omitempty"`
+	ResourceScopes []string `json:"resource_scopes,omitempty"`
+}
+
 // RetrospecTokenResult is returned when a token was checked
 type RetrospecTokenResult struct {
-	Permissions map[string]string `json:"permissions,omitempty"`
-	Exp         *int              `json:"exp,omitempty"`
-	Nbf         *int              `json:"nbf,omitempty"`
-	Iat         *int              `json:"iat,omitempty"`
-	Aud         *StringOrArray    `json:"aud,omitempty"`
-	Active      *bool             `json:"active"`
-	AuthTime    *int              `json:"auth_time,omitempty"`
-	Jti         *string           `json:"jti,omitempty"`
-	Type        *string           `json:"typ,omitempty"`
+	Permissions []*ResourcePermission `json:"permissions,omitempty"`
+	Exp         *int                  `json:"exp,omitempty"`
+	Nbf         *int                  `json:"nbf,omitempty"`
+	Iat         *int                  `json:"iat,omitempty"`
+	Aud         *StringOrArray        `json:"aud,omitempty"`
+	Active      *bool                 `json:"active"`
+	AuthTime    *int                  `json:"auth_time,omitempty"`
+	Jti         *string               `json:"jti,omitempty"`
+	Type        *string               `json:"typ,omitempty"`
 }
 
 // User represents the Keycloak User Structure

--- a/models.go
+++ b/models.go
@@ -91,7 +91,8 @@ type IssuerResponse struct {
 
 // ResourcePermission represents a permission granted to a resource
 type ResourcePermission struct {
-	RSID           *string  `json:"rsid"`
+	RSID           *string  `json:"rsid,omitempty"`
+	ResourceID     *string  `json:"resource_id,omitempty"`
 	RSName         *string  `json:"rsname,omitempty"`
 	Scopes         []string `json:"scopes,omitempty"`
 	ResourceScopes []string `json:"resource_scopes,omitempty"`


### PR DESCRIPTION
Adding proper permission for the `RetrospecTokenResult`.
