### PR TITLE
Request permission

### DIFF
--- a/client.go
+++ b/client.go
@@ -370,18 +370,6 @@ func (client *gocloak) LogoutPublicClient(clientID, realm, accessToken, refreshT
 	return checkForError(resp, err)
 }
 
-// RequestPermission request a permission
-func (client *gocloak) RequestPermission(clientID, clientSecret, realm, username, password string, permission string) (*JWT, error) {
-	return client.GetToken(realm, TokenOptions{
-		ClientID:     &clientID,
-		ClientSecret: &clientSecret,
-		GrantType:    StringP("password"),
-		Username:     &username,
-		Password:     &password,
-		Permission:   &permission,
-	})
-}
-
 // ExecuteActionsEmail executes an actions email
 func (client *gocloak) ExecuteActionsEmail(token, realm string, params ExecuteActionsEmail) error {
 	queryParams, err := GetQueryParams(params)

--- a/client_test.go
+++ b/client_test.go
@@ -742,6 +742,9 @@ func TestGocloak_GetRequestingPartyToken(t *testing.T) {
 	)
 	assert.NoError(t, err, "Get requesting party token failed")
 	t.Logf("New RPT: %+v", *rpt)
+
+	_, err = client.RetrospectToken(rpt.AccessToken, cfg.GoCloak.ClientID, cfg.GoCloak.ClientSecret, cfg.GoCloak.Realm)
+	assert.NoError(t, err, "RetrospectToken failed")
 }
 
 func TestGocloak_LoginClient(t *testing.T) {

--- a/gocloak.go
+++ b/gocloak.go
@@ -26,8 +26,6 @@ type GoCloak interface {
 	LoginClient(clientID, clientSecret, realm string) (*JWT, error)
 	// LoginAdmin login as admin
 	LoginAdmin(username, password, realm string) (*JWT, error)
-	// RequestPermission sends a request to the token endpoint with permission parameter
-	RequestPermission(clientID, clientSecret, realm, username, password, permission string) (*JWT, error)
 	// RefreshToken used to refresh the token
 	RefreshToken(refreshToken string, clientID, clientSecret, realm string) (*JWT, error)
 	// DecodeAccessToken decodes the accessToken

--- a/models.go
+++ b/models.go
@@ -89,17 +89,25 @@ type IssuerResponse struct {
 	TokensNotBefore *int    `json:"tokens-not-before,omitempty"`
 }
 
+// ResourcePermission represents a permission granted to a resource
+type ResourcePermission struct {
+	RSID           *string  `json:"rsid"`
+	RSName         *string  `json:"rsname,omitempty"`
+	Scopes         []string `json:"scopes,omitempty"`
+	ResourceScopes []string `json:"resource_scopes,omitempty"`
+}
+
 // RetrospecTokenResult is returned when a token was checked
 type RetrospecTokenResult struct {
-	Permissions map[string]string `json:"permissions,omitempty"`
-	Exp         *int              `json:"exp,omitempty"`
-	Nbf         *int              `json:"nbf,omitempty"`
-	Iat         *int              `json:"iat,omitempty"`
-	Aud         *StringOrArray    `json:"aud,omitempty"`
-	Active      *bool             `json:"active"`
-	AuthTime    *int              `json:"auth_time,omitempty"`
-	Jti         *string           `json:"jti,omitempty"`
-	Type        *string           `json:"typ,omitempty"`
+	Permissions []*ResourcePermission `json:"permissions,omitempty"`
+	Exp         *int                  `json:"exp,omitempty"`
+	Nbf         *int                  `json:"nbf,omitempty"`
+	Iat         *int                  `json:"iat,omitempty"`
+	Aud         *StringOrArray        `json:"aud,omitempty"`
+	Active      *bool                 `json:"active"`
+	AuthTime    *int                  `json:"auth_time,omitempty"`
+	Jti         *string               `json:"jti,omitempty"`
+	Type        *string               `json:"typ,omitempty"`
 }
 
 // User represents the Keycloak User Structure

--- a/models.go
+++ b/models.go
@@ -91,7 +91,8 @@ type IssuerResponse struct {
 
 // ResourcePermission represents a permission granted to a resource
 type ResourcePermission struct {
-	RSID           *string  `json:"rsid"`
+	RSID           *string  `json:"rsid,omitempty"`
+	ResourceID     *string  `json:"resource_id,omitempty"`
 	RSName         *string  `json:"rsname,omitempty"`
 	Scopes         []string `json:"scopes,omitempty"`
 	ResourceScopes []string `json:"resource_scopes,omitempty"`


### PR DESCRIPTION
Depends-on https://github.com/Nerzal/gocloak/pull/122

Removing `RequestPermission` as it's intended functionality is covered by `GetRequestingPartyToken`. Adding some coverage to `Permissions` in `RetrospecTokenResult`.
