### PR TITLE
Fix golangci-lint issues

### DIFF
--- a/client.go
+++ b/client.go
@@ -1514,7 +1514,7 @@ func (client *gocloak) GetPolicies(token string, realm string, clientID string, 
 // CreatePolicy creates a policy associated with the client
 func (client *gocloak) CreatePolicy(token string, realm string, clientID string, policy PolicyRepresentation) (*PolicyRepresentation, error) {
 	if NilOrEmpty(policy.Type) {
-		return nil, errors.New("Type of a policy required")
+		return nil, errors.New("type of a policy required")
 	}
 	var result PolicyRepresentation
 	resp, err := client.getRequestWithBearerAuth(token).
@@ -1590,7 +1590,7 @@ func (client *gocloak) GetPermissions(token string, realm string, clientID strin
 // CreatePermission creates a permission associated with the client
 func (client *gocloak) CreatePermission(token string, realm string, clientID string, permission PermissionRepresentation) (*PermissionRepresentation, error) {
 	if NilOrEmpty(permission.Type) {
-		return nil, errors.New("Type of a permission required")
+		return nil, errors.New("type of a permission required")
 	}
 	var result PermissionRepresentation
 	resp, err := client.getRequestWithBearerAuth(token).

--- a/client_test.go
+++ b/client_test.go
@@ -537,6 +537,7 @@ func TestGocloak_RequestPermission(t *testing.T) {
 		},
 	})
 	assert.Error(t, err, "GetRequestingPartyToken failed")
+	assert.Nil(t, rpt)
 
 	rpt, err = client.GetRequestingPartyToken(token.AccessToken, cfg.GoCloak.Realm, RequestingPartyTokenOptions{
 		Audience: StringP(cfg.GoCloak.ClientID),
@@ -545,6 +546,7 @@ func TestGocloak_RequestPermission(t *testing.T) {
 		},
 	})
 	assert.NoError(t, err, "GetRequestingPartyToken failed")
+	assert.NotNil(t, rpt)
 
 	rptResult, err := client.RetrospectToken(
 		rpt.AccessToken,


### PR DESCRIPTION
```
% golangci-lint run ./...
client_test.go:533:2: SA4006: this value of `rpt` is never used (staticcheck)
        rpt, err := client.GetRequestingPartyToken(token.AccessToken, cfg.GoCloak.Realm, RequestingPartyTokenOptions{
        ^
client.go:1517:26: error strings should not be capitalized or end with punctuation or a newline (golint)
                return nil, errors.New("Type of a policy required")
                                       ^
client.go:1593:26: error strings should not be capitalized or end with punctuation or a newline (golint)
                return nil, errors.New("Type of a permission required")
```