### PR TITLE
Adding AddClientRoleComposite and DeleteClientRoleComposite methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ type GoCloak interface {
 	GetClientRoles(accessToken string, realm string, clientID string) ([]*Role, error)
 	GetClientRole(token string, realm string, clientID string, roleName string) (*Role, error)
 	GetClients(accessToken string, realm string, params GetClientsParams) ([]*Client, error)
+	AddClientRoleComposite(token string, realm string, roleID string, roles []Role) error
+	DeleteClientRoleComposite(token string, realm string, roleID string, roles []Role) error
 	GetUsersByRoleName(token string, realm string, roleName string) ([]*User, error)
 	UserAttributeContains(attributes map[string][]string, attribute string, value string) bool
 	CreateClientProtocolMapper(token, realm, clientID string, mapper ProtocolMapperRepresentation) error

--- a/client.go
+++ b/client.go
@@ -1279,6 +1279,24 @@ func (client *gocloak) DeleteClientRoleFromUser(token string, realm string, clie
 	return checkForError(resp, err)
 }
 
+// AddClientRoleComposite adds roles as composite
+func (client *gocloak) AddClientRoleComposite(token string, realm string, roleID string, roles []Role) error {
+	resp, err := client.getRequestWithBearerAuth(token).
+		SetBody(roles).
+		Post(client.getAdminRealmURL(realm, "roles-by-id", roleID, "composites"))
+
+	return checkForError(resp, err)
+}
+
+// DeleteClientRoleComposite deletes composites from a role
+func (client *gocloak) DeleteClientRoleComposite(token string, realm string, roleID string, roles []Role) error {
+	resp, err := client.getRequestWithBearerAuth(token).
+		SetBody(roles).
+		Delete(client.getAdminRealmURL(realm, "roles-by-id", roleID, "composites"))
+
+	return checkForError(resp, err)
+}
+
 // ------------------
 // Identity Providers
 // ------------------

--- a/client_test.go
+++ b/client_test.go
@@ -2343,7 +2343,7 @@ func TestGocloak_AddClientRoleToUser_DeleteClientRoleFromUser(t *testing.T) {
 	assert.NoError(t, err, "DeleteClientRoleFromUser failed")
 }
 
-func TestGocloak_AddClientRoleComposite(t *testing.T) {
+func TestGocloak_AddDeleteClientRoleComposite(t *testing.T) {
 	t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
@@ -2356,41 +2356,18 @@ func TestGocloak_AddClientRoleComposite(t *testing.T) {
 	defer tearDown()
 
 	compositeRoleModel, err := client.GetClientRole(token.AccessToken, cfg.GoCloak.Realm, gocloakClientID, compositeRole)
-	FailIfErr(t, err, "Can't get just created role with GetClientRole")
+	assert.NoError(t, err, "Can't get just created role with GetClientRole")
 
 	roleModel, err := client.GetClientRole(token.AccessToken, cfg.GoCloak.Realm, gocloakClientID, role)
-	FailIfErr(t, err, "Can't get just created role with GetClientRole")
+	assert.NoError(t, err, "Can't get just created role with GetClientRole")
 
 	err = client.AddClientRoleComposite(token.AccessToken,
 		cfg.GoCloak.Realm, *(compositeRoleModel.ID), []Role{*roleModel})
-	FailIfErr(t, err, "AddClientRoleComposite failed")
-}
-
-func TestGocloak_DeleteClientRoleComposite(t *testing.T) {
-	t.Parallel()
-	cfg := GetConfig(t)
-	client := NewClientWithDebug(t)
-	token := GetAdminToken(t, client)
-
-	tearDown, compositeRole := CreateClientRole(t, client)
-	defer tearDown()
-
-	tearDown, role := CreateClientRole(t, client)
-	defer tearDown()
-
-	compositeRoleModel, err := client.GetClientRole(token.AccessToken, cfg.GoCloak.Realm, gocloakClientID, compositeRole)
-	FailIfErr(t, err, "Can't get just created role with GetClientRole")
-
-	roleModel, err := client.GetClientRole(token.AccessToken, cfg.GoCloak.Realm, gocloakClientID, role)
-	FailIfErr(t, err, "Can't get just created role with GetClientRole")
-
-	err = client.AddClientRoleComposite(token.AccessToken,
-		cfg.GoCloak.Realm, *(compositeRoleModel.ID), []Role{*roleModel})
-	FailIfErr(t, err, "AddClientRoleComposite failed")
+	assert.NoError(t, err, "AddClientRoleComposite failed")
 
 	err = client.DeleteClientRoleComposite(token.AccessToken,
 		cfg.GoCloak.Realm, *(compositeRoleModel.ID), []Role{*roleModel})
-	FailIfErr(t, err, "DeleteClientRoleComposite failed")
+	assert.NoError(t, err, "DeleteClientRoleComposite failed")
 }
 
 func TestGocloak_CreateDeleteClientScopeWithMappers(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -2343,6 +2343,56 @@ func TestGocloak_AddClientRoleToUser_DeleteClientRoleFromUser(t *testing.T) {
 	assert.NoError(t, err, "DeleteClientRoleFromUser failed")
 }
 
+func TestGocloak_AddClientRoleComposite(t *testing.T) {
+	t.Parallel()
+	cfg := GetConfig(t)
+	client := NewClientWithDebug(t)
+	token := GetAdminToken(t, client)
+
+	tearDown, compositeRole := CreateClientRole(t, client)
+	defer tearDown()
+
+	tearDown, role := CreateClientRole(t, client)
+	defer tearDown()
+
+	compositeRoleModel, err := client.GetClientRole(token.AccessToken, cfg.GoCloak.Realm, gocloakClientID, compositeRole)
+	FailIfErr(t, err, "Can't get just created role with GetClientRole")
+
+	roleModel, err := client.GetClientRole(token.AccessToken, cfg.GoCloak.Realm, gocloakClientID, role)
+	FailIfErr(t, err, "Can't get just created role with GetClientRole")
+
+	err = client.AddClientRoleComposite(token.AccessToken,
+		cfg.GoCloak.Realm, *(compositeRoleModel.ID), []Role{*roleModel})
+	FailIfErr(t, err, "AddClientRoleComposite failed")
+}
+
+func TestGocloak_DeleteClientRoleComposite(t *testing.T) {
+	t.Parallel()
+	cfg := GetConfig(t)
+	client := NewClientWithDebug(t)
+	token := GetAdminToken(t, client)
+
+	tearDown, compositeRole := CreateClientRole(t, client)
+	defer tearDown()
+
+	tearDown, role := CreateClientRole(t, client)
+	defer tearDown()
+
+	compositeRoleModel, err := client.GetClientRole(token.AccessToken, cfg.GoCloak.Realm, gocloakClientID, compositeRole)
+	FailIfErr(t, err, "Can't get just created role with GetClientRole")
+
+	roleModel, err := client.GetClientRole(token.AccessToken, cfg.GoCloak.Realm, gocloakClientID, role)
+	FailIfErr(t, err, "Can't get just created role with GetClientRole")
+
+	err = client.AddClientRoleComposite(token.AccessToken,
+		cfg.GoCloak.Realm, *(compositeRoleModel.ID), []Role{*roleModel})
+	FailIfErr(t, err, "AddClientRoleComposite failed")
+
+	err = client.DeleteClientRoleComposite(token.AccessToken,
+		cfg.GoCloak.Realm, *(compositeRoleModel.ID), []Role{*roleModel})
+	FailIfErr(t, err, "DeleteClientRoleComposite failed")
+}
+
 func TestGocloak_CreateDeleteClientScopeWithMappers(t *testing.T) {
 	t.Parallel()
 	cfg := GetConfig(t)

--- a/gocloak.go
+++ b/gocloak.go
@@ -170,6 +170,10 @@ type GoCloak interface {
 	GetClientRoles(accessToken string, realm string, clientID string) ([]*Role, error)
 	// GetClientRole get a role for the given client in a realm by role name
 	GetClientRole(token string, realm string, clientID string, roleName string) (*Role, error)
+	// AddClientRoleComposite adds roles as composite
+	AddClientRoleComposite(token string, realm string, roleID string, roles []Role) error
+	// DeleteClientRoleComposite deletes composites from a role
+	DeleteClientRoleComposite(token string, realm string, roleID string, roles []Role) error
 
 	// *** Realm ***
 


### PR DESCRIPTION
These methods will allow for managing composite roles for clients.

It appears that these methods will work for both client and realm composite roles which the current `AddRealmRoleComposite` and `DeleteRealmRoleComposite` only work for realm composite roles.