### PR TITLE
Adding AddRealmRoleToGroup and DeleteRealmRoleFromGroup methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ type GoCloak interface {
 	DeleteRealmRole(token string, realm string, roleName string) error
 	AddRealmRoleToUser(token string, realm string, userID string, roles []Role) error
 	DeleteRealmRoleFromUser(token string, realm string, userID string, roles []Role) error
-    AddRealmRoleToGroup(token string, realm string, groupID string, roles []Role) error
+	AddRealmRoleToGroup(token string, realm string, groupID string, roles []Role) error
 	DeleteRealmRoleFromGroup(token string, realm string, groupID string, roles []Role) error
 	AddRealmRoleComposite(token string, realm string, roleName string, roles []Role) error
 	DeleteRealmRoleComposite(token string, realm string, roleName string, roles []Role) error

--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ type GoCloak interface {
 	DeleteRealmRole(token string, realm string, roleName string) error
 	AddRealmRoleToUser(token string, realm string, userID string, roles []Role) error
 	DeleteRealmRoleFromUser(token string, realm string, userID string, roles []Role) error
+    AddRealmRoleToGroup(token string, realm string, groupID string, roles []Role) error
+	DeleteRealmRoleFromGroup(token string, realm string, groupID string, roles []Role) error
 	AddRealmRoleComposite(token string, realm string, roleName string, roles []Role) error
 	DeleteRealmRoleComposite(token string, realm string, roleName string, roles []Role) error
 

--- a/client.go
+++ b/client.go
@@ -1087,6 +1087,24 @@ func (client *gocloak) DeleteRealmRoleFromUser(token string, realm string, userI
 	return checkForError(resp, err)
 }
 
+// AddRealmRoleToGroup adds realm-level role mappings
+func (client *gocloak) AddRealmRoleToGroup(token string, realm string, groupID string, roles []Role) error {
+	resp, err := client.getRequestWithBearerAuth(token).
+		SetBody(roles).
+		Post(client.getAdminRealmURL(realm, "groups", groupID, "role-mappings", "realm"))
+
+	return checkForError(resp, err)
+}
+
+// DeleteRealmRoleFromGroup deletes realm-level role mappings
+func (client *gocloak) DeleteRealmRoleFromGroup(token string, realm string, groupID string, roles []Role) error {
+	resp, err := client.getRequestWithBearerAuth(token).
+		SetBody(roles).
+		Delete(client.getAdminRealmURL(realm, "groups", groupID, "role-mappings", "realm"))
+
+	return checkForError(resp, err)
+}
+
 func (client *gocloak) AddRealmRoleComposite(token string, realm string, roleName string, roles []Role) error {
 	resp, err := client.getRequestWithBearerAuth(token).
 		SetBody(roles).

--- a/client_test.go
+++ b/client_test.go
@@ -1613,6 +1613,39 @@ func TestGocloak_AddRealmRoleToUser_DeleteRealmRoleFromUser(t *testing.T) {
 	assert.NoError(t, err, "DeleteRealmRoleFromUser failed")
 }
 
+func TestGocloak_AddRealmRoleToGroup_DeleteRealmRoleFromGroup(t *testing.T) {
+	t.Parallel()
+	cfg := GetConfig(t)
+	client := NewClientWithDebug(t)
+	token := GetAdminToken(t, client)
+
+	tearDownGroup, groupID := CreateGroup(t, client)
+	defer tearDownGroup()
+	tearDownRole, roleName := CreateRealmRole(t, client)
+	defer tearDownRole()
+	role, err := client.GetRealmRole(
+		token.AccessToken,
+		cfg.GoCloak.Realm,
+		roleName)
+	assert.NoError(t, err, "GetRealmRole failed")
+
+	roles := []Role{*role}
+	err = client.AddRealmRoleToGroup(
+		token.AccessToken,
+		cfg.GoCloak.Realm,
+		groupID,
+		roles,
+	)
+	assert.NoError(t, err, "AddRealmRoleToGroup failed")
+	err = client.DeleteRealmRoleFromGroup(
+		token.AccessToken,
+		cfg.GoCloak.Realm,
+		groupID,
+		roles,
+	)
+	assert.NoError(t, err, "DeleteRealmRoleFromGroup failed")
+}
+
 func TestGocloak_GetRealmRolesByUserID(t *testing.T) {
 	t.Parallel()
 	cfg := GetConfig(t)

--- a/gocloak.go
+++ b/gocloak.go
@@ -153,6 +153,10 @@ type GoCloak interface {
 	AddRealmRoleToUser(token string, realm string, userID string, roles []Role) error
 	// DeleteRealmRoleFromUser deletes realm-level role mappings
 	DeleteRealmRoleFromUser(token string, realm string, userID string, roles []Role) error
+	// AddRealmRoleToGroup adds realm-level role mappings
+	AddRealmRoleToGroup(token string, realm string, groupID string, roles []Role) error
+	// DeleteRealmRoleFromGroup deletes realm-level role mappings
+	DeleteRealmRoleFromGroup(token string, realm string, groupID string, roles []Role) error
 	// AddRealmRoleComposite adds roles as composite
 	AddRealmRoleComposite(token string, realm string, roleName string, roles []Role) error
 	// AddRealmRoleComposite adds roles as composite


### PR DESCRIPTION
These methods will allow for managing realm roles for groups. Currently it is only supported for users

