### PR TITLE
Adding GetCompositeClientRolesByRoleID method

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ type GoCloak interface {
 
 	AddClientRoleToGroup(token string, realm string, clientID string, groupID string, roles []Role) error
 	DeleteClientRoleFromGroup(token string, realm string, clientID string, groupID string, roles []Role) error
+	GetCompositeClientRolesByRoleID(token string, realm string, clientID string, roleID string) ([]*Role, error)
 	GetClientRolesByUserID(token string, realm string, clientID string, userID string) ([]*Role, error)
 	GetClientRolesByGroupID(token string, realm string, clientID string, groupID string) ([]*Role, error)
 	GetCompositeClientRolesByUserID(token string, realm string, clientID string, userID string) ([]*Role, error)

--- a/client.go
+++ b/client.go
@@ -908,6 +908,20 @@ func (client *gocloak) GetClientRolesByGroupID(token string, realm string, clien
 	return result, nil
 }
 
+// GetCompositeClientRolesByRoleID returns all client composite roles associated with the given client role
+func (client *gocloak) GetCompositeClientRolesByRoleID(token string, realm string, clientID string, roleID string) ([]*Role, error) {
+	var result []*Role
+	resp, err := client.getRequestWithBearerAuth(token).
+		SetResult(&result).
+		Get(client.getAdminRealmURL(realm, "roles-by-id", roleID, "composites", "clients", clientID))
+
+	if err = checkForError(resp, err); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 // GetCompositeClientRolesByUserID returns all client roles and composite roles assigned to the given user
 func (client *gocloak) GetCompositeClientRolesByUserID(token string, realm string, clientID string, userID string) ([]*Role, error) {
 	var result []*Role

--- a/client_test.go
+++ b/client_test.go
@@ -2515,6 +2515,12 @@ func TestGocloak_AddDeleteClientRoleComposite(t *testing.T) {
 		cfg.GoCloak.Realm, *(compositeRoleModel.ID), []Role{*roleModel})
 	assert.NoError(t, err, "AddClientRoleComposite failed")
 
+	compositeRoles, err := client.GetCompositeClientRolesByRoleID(token.AccessToken,
+		cfg.GoCloak.Realm, gocloakClientID, *(compositeRoleModel.ID))
+	assert.NoError(t, err, "GetCompositeClientRolesByRoleID failed")
+	assert.GreaterOrEqual(t, len(compositeRoles), 1, "GetCompositeClientRolesByRoleID didn't return any composite roles")
+	assert.Equal(t, *(roleModel.ID), *(compositeRoles[0].ID), "GetCompositeClientRolesByRoleID returned wrong composite role")
+
 	err = client.DeleteClientRoleComposite(token.AccessToken,
 		cfg.GoCloak.Realm, *(compositeRoleModel.ID), []Role{*roleModel})
 	assert.NoError(t, err, "DeleteClientRoleComposite failed")

--- a/gocloak.go
+++ b/gocloak.go
@@ -178,6 +178,8 @@ type GoCloak interface {
 	GetClientRolesByUserID(token string, realm string, clientID string, userID string) ([]*Role, error)
 	// GetClientRolesByGroupID returns all client roles assigned to the given group
 	GetClientRolesByGroupID(token string, realm string, clientID string, groupID string) ([]*Role, error)
+	// GetCompositeClientRolesByRoleID returns all client composite roles associated with the given client role
+	GetCompositeClientRolesByRoleID(token string, realm string, clientID string, roleID string) ([]*Role, error)
 	// GetCompositeClientRolesByUserID returns all client roles and composite roles assigned to the given user
 	GetCompositeClientRolesByUserID(token string, realm string, clientID string, userID string) ([]*Role, error)
 	// GetCompositeClientRolesByGroupID returns all client roles and composite roles assigned to the given group


### PR DESCRIPTION
This allows a user to get all the composite roles from for given client role.