### PR TITLE
GolangCi enable comments validation

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,9 +33,12 @@ linters-settings:
     simplify: true
 
 issues:
+  exclude-use-default: false
   exclude-rules:
     - path: _test\.go
       linters:
         - gocyclo
         - dupl
         - gosec
+  exclude:
+    - should have a package comment

--- a/errors.go
+++ b/errors.go
@@ -32,7 +32,7 @@ func (e HTTPErrorResponse) String() string {
 	return res.String()
 }
 
-// HasError validates that error is not emptyp
+// NotEmpty validates that error is not emptyp
 func (e HTTPErrorResponse) NotEmpty() bool {
 	return len(e.Error) > 0 || len(e.Message) > 0 || len(e.Description) > 0
 }

--- a/models.go
+++ b/models.go
@@ -255,6 +255,8 @@ type GetGroupsParams struct {
 	BriefRepresentation *bool   `json:"briefRepresentation,string,omitempty"`
 }
 
+// MarshalJSON is a custom json marshaling function to automatically set the Full and BriefRepresentation properties
+// for backward compatibility
 func (obj GetGroupsParams) MarshalJSON() ([]byte, error) {
 	type Alias GetGroupsParams
 	a := (Alias)(obj)


### PR DESCRIPTION
I found that the GoReportCard shows some errors in the comments, but the GolangCI ignores those comments. So found how to enable this validation and fixed those errors