### PR TITLE
Extend UserInfo according to the specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ type GoCloak interface {
 	GetCerts(ctx context.Context, realm string) (*CertResponse, error)
 	GetServerInfo(ctx context.Context, accessToken string) (*ServerInfoRepesentation, error)
 	GetUserInfo(ctx context.Context, accessToken, realm string) (*UserInfo, error)
+	GetRawUserInfo(ctx context.Context, accessToken, realm string) (map[string]interface{}, error)
 	SetPassword(ctx context.Context, token, userID, realm, password string, temporary bool) error
 	ExecuteActionsEmail(ctx context.Context, token, realm string, params ExecuteActionsEmail) error
 

--- a/client.go
+++ b/client.go
@@ -181,6 +181,22 @@ func (client *gocloak) GetUserInfo(ctx context.Context, accessToken, realm strin
 	return &result, nil
 }
 
+// GetRawUserInfo calls the UserInfo endpoint and returns a raw json object
+func (client *gocloak) GetRawUserInfo(ctx context.Context, accessToken, realm string) (map[string]interface{}, error) {
+	const errMessage = "could not get user info"
+
+	var result map[string]interface{}
+	resp, err := client.getRequestWithBearerAuth(ctx, accessToken).
+		SetResult(&result).
+		Get(client.getRealmURL(realm, openIDConnect, "userinfo"))
+
+	if err := checkForError(resp, err, errMessage); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 func (client *gocloak) getNewCerts(ctx context.Context, realm string) (*CertResponse, error) {
 	const errMessage = "could not get newCerts"
 

--- a/client_test.go
+++ b/client_test.go
@@ -516,6 +516,21 @@ func TestGocloak_GetUserInfo(t *testing.T) {
 	require.Error(t, err, "")
 }
 
+func TestGocloak_GetRawUserInfo(t *testing.T) {
+	t.Parallel()
+	cfg := GetConfig(t)
+	client := NewClientWithDebug(t)
+	token := GetClientToken(t, client)
+	userInfo, err := client.GetUserInfo(
+		context.Background(),
+		token.AccessToken,
+		cfg.GoCloak.Realm,
+	)
+	require.NoError(t, err, "Failed to fetch userinfo")
+	t.Log(userInfo)
+	require.NotEmpty(t, userInfo)
+}
+
 func TestGocloak_RequestPermission(t *testing.T) {
 	t.Parallel()
 	cfg := GetConfig(t)

--- a/gocloak.go
+++ b/gocloak.go
@@ -46,6 +46,8 @@ type GoCloak interface {
 	GetServerInfo(ctx context.Context, accessToken string) (*ServerInfoRepesentation, error)
 	// GetUserInfo gets the user info for the given realm
 	GetUserInfo(ctx context.Context, accessToken, realm string) (*UserInfo, error)
+	// GetRawUserInfo calls the UserInfo endpoint and returns a raw json object
+	GetRawUserInfo(ctx context.Context, accessToken, realm string) (map[string]interface{}, error)
 
 	// ExecuteActionsEmail executes an actions email
 	ExecuteActionsEmail(ctx context.Context, token, realm string, params ExecuteActionsEmail) error

--- a/models.go
+++ b/models.go
@@ -544,13 +544,39 @@ type GetClientsParams struct {
 	ViewableOnly *bool   `json:"viewableOnly,string"`
 }
 
+// UserInfoAddress is representation of the address sub-filed of UserInfo
+// https://openid.net/specs/openid-connect-core-1_0.html#AddressClaim
+type UserInfoAddress struct {
+	Formatted     *string `json:"formatted,omitempty"`
+	StreetAddress *string `json:"street_address,omitempty"`
+	Locality      *string `json:"locality,omitempty"`
+	Region        *string `json:"region,omitempty"`
+	PostalCode    *string `json:"postal_code,omitempty"`
+	Country       *string `json:"country,omitempty"`
+}
+
 // UserInfo is returned by the userinfo endpoint
+// https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
 type UserInfo struct {
-	Sub               *string      `json:"sub,omitempty"`
-	EmailVerified     *bool        `json:"email_verified"`
-	Address           *interface{} `json:"address,omitempty"`
-	PreferredUsername *string      `json:"preferred_username,omitempty"`
-	Email             *string      `json:"email,omitempty"`
+	Sub                 *string          `json:"sub,omitempty"`
+	Name                *string          `json:"name,omitempty"`
+	GivenName           *string          `json:"given_name,omitempty"`
+	FamilyName          *string          `json:"family_name,omitempty"`
+	MiddleName          *string          `json:"middle_name,omitempty"`
+	Nickname            *string          `json:"nickname,omitempty"`
+	PreferredUsername   *string          `json:"preferred_username,omitempty"`
+	Profile             *string          `json:"profile,omitempty"`
+	Picture             *string          `json:"picture,omitempty"`
+	Website             *string          `json:"website,omitempty"`
+	Email               *string          `json:"email,omitempty"`
+	EmailVerified       *bool            `json:"email_verified,omitempty"`
+	Gender              *string          `json:"gender,omitempty"`
+	ZoneInfo            *string          `json:"zoneinfo,omitempty"`
+	Locale              *string          `json:"locale,omitempty"`
+	PhoneNumber         *string          `json:"phone_number,omitempty"`
+	PhoneNumberVerified *bool            `json:"phone_number_verified,omitempty"`
+	Address             *UserInfoAddress `json:"address,omitempty"`
+	UpdatedAt           *int             `json:"updated_at,omitempty"`
 }
 
 // RealmRepresentation represent a realm


### PR DESCRIPTION
UserInfo claims specification: https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
Address claim: https://openid.net/specs/openid-connect-core-1_0.html#AddressClaim
    
Add GetRawUserInfo that returns map[string]interface{} to support custom claims

Fix #173