### PR TITLE
Let checkForError return original error message

### DIFF
--- a/client.go
+++ b/client.go
@@ -73,7 +73,7 @@ func checkForError(resp *resty.Response, err error, errMessage string) error {
 	if err != nil {
 		return &APIError{
 			Code:    0,
-			Message: errMessage,
+			Message: errors.Wrap(err, errMessage).Error(),
 		}
 	}
 


### PR DESCRIPTION
The `checkForError` function returns the hardcoded error message without containing the original error message, which makes it nearly impossible to debug. For example, a returned error message may look like 

```
2020/08/07 13:05:38 http: panic serving 127.0.0.1:62407: could not get token
```

However, it's not so useful since we have no clues for what's happening under the hood.

This PR wraps the original error with the given error message so that we are able to see what's happening. After this PR, the error message will be like

```
http: panic serving 127.0.0.1:62677: could not get token: Post "https://example.com/auth/realms/master/protocol/openid-connect/token": x509: certificate signed by unknown authority
```
