### PR TITLE
Add support for enabled and exact query params in list users query

### DIFF
--- a/models.go
+++ b/models.go
@@ -220,6 +220,7 @@ type UserGroup struct {
 type GetUsersParams struct {
 	BriefRepresentation *bool   `json:"briefRepresentation,string"`
 	Email               *string `json:"email,omitempty"`
+	Exact               *bool   `json:"exact,omitempty"`
 	First               *int    `json:"first,string,omitempty"`
 	FirstName           *string `json:"firstName,omitempty"`
 	LastName            *string `json:"lastName,omitempty"`

--- a/models.go
+++ b/models.go
@@ -220,6 +220,7 @@ type UserGroup struct {
 type GetUsersParams struct {
 	BriefRepresentation *bool   `json:"briefRepresentation,string"`
 	Email               *string `json:"email,omitempty"`
+	Enabled             *bool   `json:"enabled,omitempty"`
 	Exact               *bool   `json:"exact,omitempty"`
 	First               *int    `json:"first,string,omitempty"`
 	FirstName           *string `json:"firstName,omitempty"`


### PR DESCRIPTION
This adds support for the two parameters which are supported by Keycloak 11 as described in the [docs](https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_users_resource) 