### PR TITLE
Add a token refresher

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,25 @@ go get github.com/Nerzal/gocloak/v7
 	// Do something with the permissions ;)
 ```
 
+### Refresh Tokens
+
+Using the `TokenRefresher`, tokens will be refreshed in the background rather
+than needing additional work from you.
+
+```go
+    refresher := NewTokenRefresher(context.Background(), &RefreshConfig{
+        Domain:             domain,
+        ClientId:           clientId, 
+        ClientSecret:       clientSecret, 
+        Realm:              realm,
+        EarlyRefreshSecs:   5,
+    })
+    groups, err := GetGroups(ctx, refresher.AccessToken(), realm, params)
+    if err != nil {
+        panic("Getting groups failed:"+ err.Error())
+    }
+```
+
 ## Features
 
 ```go

--- a/tokenrefresher.go
+++ b/tokenrefresher.go
@@ -1,0 +1,117 @@
+package gocloak
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+type RefreshConfig struct {
+	Domain, ClientId, ClientSecret, Realm string
+
+	// The number of seconds early to refresh a token.
+	EarlyRefreshSecs int
+}
+
+// newTokenRefresher starts a background service that refreshes our jwt for us
+// whenever it's going to expire. It's thread-safe.
+func NewTokenRefresher(ctx context.Context, config *RefreshConfig) (*TokenRefresher, error) {
+	keycloakClient := NewClient(config.Domain)
+	jwt, err := keycloakClient.LoginClient(ctx, config.ClientId, config.ClientSecret, config.Realm)
+	if err != nil {
+		return nil, err
+	}
+	t := &TokenRefresher{
+		ctx:      ctx,
+		config:   config,
+		keycloak: keycloakClient,
+		jwt:      jwt,
+	}
+	t.startBackgroundRefresh()
+	return t, nil
+}
+
+type TokenRefresher struct {
+	ctx      context.Context
+	config   *RefreshConfig
+	keycloak GoCloak
+
+	// The mu protects the jwt from a race. We need it
+	// because it's accessed on one goroutine, but refreshed on another.
+	mu  sync.RWMutex
+	jwt *JWT
+}
+
+func (t *TokenRefresher) AccessToken() string {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	return t.jwt.AccessToken
+}
+
+// startBackgroundRefresh begins a service that is responsible for always
+// keeping the access token up-to-date.
+// If it's unable to refresh or renew a token, it logs at error level and
+// tries again each second until it's either successful, or it's not and
+// the caller will begin to experience authorization errors.
+func (t *TokenRefresher) startBackgroundRefresh() {
+	// This goroutine is the only thread _writing_ the jwt, down inside
+	// its token refreshing methods.
+	earlyRefresh := time.Duration(t.config.EarlyRefreshSecs) * time.Second
+	go func() {
+		for {
+			t.mu.RLock()
+			expirationTimer := time.NewTimer(time.Duration(t.jwt.ExpiresIn)*time.Second - earlyRefresh)
+			refreshTimer := time.NewTimer(time.Duration(t.jwt.RefreshExpiresIn)*time.Second - earlyRefresh)
+			t.mu.RUnlock()
+
+			select {
+			case <-expirationTimer.C:
+				if err := t.newToken(); err != nil {
+					t.mu.Lock()
+					t.jwt.ExpiresIn = 1
+					t.mu.Unlock()
+				}
+				continue
+
+			case <-refreshTimer.C:
+				if err := t.refreshToken(); err != nil {
+					t.mu.Lock()
+					t.jwt.RefreshExpiresIn = 1
+					t.mu.Unlock()
+				}
+				continue
+
+			case <-t.ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+func (t *TokenRefresher) newToken() error {
+	jwt, err := t.keycloak.LoginClient(t.ctx, t.config.ClientId, t.config.ClientSecret, t.config.Realm)
+	if err != nil {
+		return err
+	}
+
+	t.mu.Lock()
+	t.jwt = jwt
+	t.mu.Unlock()
+
+	return nil
+}
+
+func (t *TokenRefresher) refreshToken() error {
+	t.mu.RLock()
+	jwt, err := t.keycloak.RefreshToken(t.ctx, t.jwt.RefreshToken, t.config.ClientId, t.config.ClientSecret, t.config.Realm)
+	t.mu.RUnlock()
+	if err != nil {
+		return err
+	}
+
+	t.mu.Lock()
+	t.jwt = jwt
+	t.mu.Unlock()
+
+	return nil
+}

--- a/tokenrefresher.go
+++ b/tokenrefresher.go
@@ -86,7 +86,9 @@ func (t *TokenRefresher) startBackgroundRefresh() {
 }
 
 func (t *TokenRefresher) newToken() error {
+	t.mu.RLock()
 	jwt, err := t.keycloak.LoginClient(t.ctx, t.config.ClientId, t.config.ClientSecret, t.config.Realm)
+	t.mu.RUnlock()
 	if err != nil {
 		return err
 	}

--- a/tokenrefresher.go
+++ b/tokenrefresher.go
@@ -6,6 +6,7 @@ import (
 	"time"
 )
 
+// RefreshConfig is the configuration for the token refresher.
 type RefreshConfig struct {
 	Domain, ClientId, ClientSecret, Realm string
 
@@ -13,7 +14,7 @@ type RefreshConfig struct {
 	EarlyRefreshSecs int
 }
 
-// newTokenRefresher starts a background service that refreshes our jwt for us
+// NewTokenRefresher starts a background service that refreshes our jwt for us
 // whenever it's going to expire. It's thread-safe.
 func NewTokenRefresher(ctx context.Context, config *RefreshConfig) (*TokenRefresher, error) {
 	keycloakClient := NewClient(config.Domain)
@@ -31,6 +32,9 @@ func NewTokenRefresher(ctx context.Context, config *RefreshConfig) (*TokenRefres
 	return t, nil
 }
 
+// TokenRefresher is an object that refreshes tokens in the background.
+// To use it, please use NewTokenRefresher because it begins the
+// background refresh process.
 type TokenRefresher struct {
 	ctx      context.Context
 	config   *RefreshConfig
@@ -42,6 +46,7 @@ type TokenRefresher struct {
 	jwt *JWT
 }
 
+// AccessToken returns a jwt access token for use in client calls.
 func (t *TokenRefresher) AccessToken() string {
 	t.mu.RLock()
 	defer t.mu.RUnlock()

--- a/tokenrefresher.go
+++ b/tokenrefresher.go
@@ -8,7 +8,7 @@ import (
 
 // RefreshConfig is the configuration for the token refresher.
 type RefreshConfig struct {
-	Domain, ClientId, ClientSecret, Realm string
+	Domain, ClientID, ClientSecret, Realm string
 
 	// The number of seconds early to refresh a token.
 	EarlyRefreshSecs int
@@ -18,7 +18,7 @@ type RefreshConfig struct {
 // whenever it's going to expire. It's thread-safe.
 func NewTokenRefresher(ctx context.Context, config *RefreshConfig) (*TokenRefresher, error) {
 	keycloakClient := NewClient(config.Domain)
-	jwt, err := keycloakClient.LoginClient(ctx, config.ClientId, config.ClientSecret, config.Realm)
+	jwt, err := keycloakClient.LoginClient(ctx, config.ClientID, config.ClientSecret, config.Realm)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func (t *TokenRefresher) startBackgroundRefresh() {
 
 func (t *TokenRefresher) newToken() error {
 	t.mu.RLock()
-	jwt, err := t.keycloak.LoginClient(t.ctx, t.config.ClientId, t.config.ClientSecret, t.config.Realm)
+	jwt, err := t.keycloak.LoginClient(t.ctx, t.config.ClientID, t.config.ClientSecret, t.config.Realm)
 	t.mu.RUnlock()
 	if err != nil {
 		return err
@@ -107,7 +107,7 @@ func (t *TokenRefresher) newToken() error {
 
 func (t *TokenRefresher) refreshToken() error {
 	t.mu.RLock()
-	jwt, err := t.keycloak.RefreshToken(t.ctx, t.jwt.RefreshToken, t.config.ClientId, t.config.ClientSecret, t.config.Realm)
+	jwt, err := t.keycloak.RefreshToken(t.ctx, t.jwt.RefreshToken, t.config.ClientID, t.config.ClientSecret, t.config.Realm)
 	t.mu.RUnlock()
 	if err != nil {
 		return err

--- a/tokenrefresher.go
+++ b/tokenrefresher.go
@@ -50,9 +50,6 @@ func (t *TokenRefresher) AccessToken() string {
 
 // startBackgroundRefresh begins a service that is responsible for always
 // keeping the access token up-to-date.
-// If it's unable to refresh or renew a token, it logs at error level and
-// tries again each second until it's either successful, or it's not and
-// the caller will begin to experience authorization errors.
 func (t *TokenRefresher) startBackgroundRefresh() {
 	// This goroutine is the only thread _writing_ the jwt, down inside
 	// its token refreshing methods.

--- a/tokenrefresher_test.go
+++ b/tokenrefresher_test.go
@@ -1,0 +1,26 @@
+package gocloak_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Nerzal/gocloak/v7"
+)
+
+func TestTokenRefresher(t *testing.T) {
+	cfg := GetConfig(t)
+	refresher, err := gocloak.NewTokenRefresher(context.Background(), &gocloak.RefreshConfig{
+		Domain:           "test.io",
+		ClientId:         cfg.GoCloak.ClientID,
+		ClientSecret:     cfg.GoCloak.ClientSecret,
+		Realm:            cfg.GoCloak.Realm,
+		EarlyRefreshSecs: 5,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	token := refresher.AccessToken()
+	if token == "" {
+		t.Fatalf("expected token but received %s", token)
+	}
+}

--- a/tokenrefresher_test.go
+++ b/tokenrefresher_test.go
@@ -11,7 +11,7 @@ func TestTokenRefresher(t *testing.T) {
 	cfg := GetConfig(t)
 	refresher, err := gocloak.NewTokenRefresher(context.Background(), &gocloak.RefreshConfig{
 		Domain:           "test.io",
-		ClientId:         cfg.GoCloak.ClientID,
+		ClientID:         cfg.GoCloak.ClientID,
 		ClientSecret:     cfg.GoCloak.ClientSecret,
 		Realm:            cfg.GoCloak.Realm,
 		EarlyRefreshSecs: 5,


### PR DESCRIPTION
This PR adds a token refresher, that refreshes the token on a background goroutine.

I wrote this for myself to keep tokens up-to-date, and I found that I was reusing it quite a lot, so I thought it might be better suited to live here.