### PR TITLE
Add MatchingURI to GetResourceParams model

### DIFF
--- a/models.go
+++ b/models.go
@@ -899,14 +899,15 @@ type IdentityProviderRepresentation struct {
 
 // GetResourceParams represents the optional parameters for getting resources
 type GetResourceParams struct {
-	Deep  *bool   `json:"deep,string,omitempty"`
-	First *int    `json:"first,string,omitempty"`
-	Max   *int    `json:"max,string,omitempty"`
-	Name  *string `json:"name,omitempty"`
-	Owner *string `json:"owner,omitempty"`
-	Type  *string `json:"type,omitempty"`
-	URI   *string `json:"uri,omitempty"`
-	Scope *string `json:"scope,omitempty"`
+    Deep        *bool   `json:"deep,string,omitempty"`
+    First       *int    `json:"first,string,omitempty"`
+    Max         *int    `json:"max,string,omitempty"`
+    Name        *string `json:"name,omitempty"`
+    Owner       *string `json:"owner,omitempty"`
+    Type        *string `json:"type,omitempty"`
+    URI         *string `json:"uri,omitempty"`
+    Scope       *string `json:"scope,omitempty"`
+    MatchingURI *bool   `json:"matchingUri"`
 }
 
 // GetScopeParams represents the optional parameters for getting scopes

--- a/models.go
+++ b/models.go
@@ -899,15 +899,15 @@ type IdentityProviderRepresentation struct {
 
 // GetResourceParams represents the optional parameters for getting resources
 type GetResourceParams struct {
-    Deep        *bool   `json:"deep,string,omitempty"`
-    First       *int    `json:"first,string,omitempty"`
-    Max         *int    `json:"max,string,omitempty"`
-    Name        *string `json:"name,omitempty"`
-    Owner       *string `json:"owner,omitempty"`
-    Type        *string `json:"type,omitempty"`
-    URI         *string `json:"uri,omitempty"`
-    Scope       *string `json:"scope,omitempty"`
-    MatchingURI *bool   `json:"matchingUri,string,omitempty"`
+	Deep        *bool   `json:"deep,string,omitempty"`
+	First       *int    `json:"first,string,omitempty"`
+	Max         *int    `json:"max,string,omitempty"`
+	Name        *string `json:"name,omitempty"`
+	Owner       *string `json:"owner,omitempty"`
+	Type        *string `json:"type,omitempty"`
+	URI         *string `json:"uri,omitempty"`
+	Scope       *string `json:"scope,omitempty"`
+	MatchingURI *bool   `json:"matchingUri,string,omitempty"`
 }
 
 // GetScopeParams represents the optional parameters for getting scopes

--- a/models.go
+++ b/models.go
@@ -907,7 +907,7 @@ type GetResourceParams struct {
     Type        *string `json:"type,omitempty"`
     URI         *string `json:"uri,omitempty"`
     Scope       *string `json:"scope,omitempty"`
-    MatchingURI *bool   `json:"matchingUri"`
+    MatchingURI *bool   `json:"matchingUri,string,omitempty"`
 }
 
 // GetScopeParams represents the optional parameters for getting scopes


### PR DESCRIPTION
Added the `matchingUri` parameter to GetResourceParams model to enable the Keycloak URI path matcher.

https://github.com/keycloak/keycloak/blob/master/services/src/main/java/org/keycloak/authorization/admin/ResourceSetService.java#L337