### PR TITLE
Implemented Bearer check/removal from passed token

### DIFF
--- a/client.go
+++ b/client.go
@@ -350,6 +350,7 @@ func (client *gocloak) RetrospectToken(ctx context.Context, accessToken, clientI
 // DecodeAccessToken decodes the accessToken
 func (client *gocloak) DecodeAccessToken(ctx context.Context, accessToken, realm, expectedAudience string) (*jwt.Token, *jwt.MapClaims, error) {
 	const errMessage = "could not decode access token"
+	accessToken = strings.Replace(accessToken, "Bearer ", "", 1)
 
 	decodedHeader, err := jwx.DecodeAccessTokenHeader(accessToken)
 	if err != nil {
@@ -374,6 +375,7 @@ func (client *gocloak) DecodeAccessToken(ctx context.Context, accessToken, realm
 // DecodeAccessTokenCustomClaims decodes the accessToken and writes claims into the given claims
 func (client *gocloak) DecodeAccessTokenCustomClaims(ctx context.Context, accessToken, realm, expectedAudience string, claims jwt.Claims) (*jwt.Token, error) {
 	const errMessage = "could not decode access token with custom claims"
+	accessToken = strings.Replace(accessToken, "Bearer ", "", 1)
 
 	decodedHeader, err := jwx.DecodeAccessTokenHeader(accessToken)
 	if err != nil {

--- a/pkg/jwx/jwx.go
+++ b/pkg/jwx/jwx.go
@@ -77,6 +77,7 @@ func decodePublicKey(e, n *string) (*rsa.PublicKey, error) {
 // DecodeAccessToken currently only supports RSA - sorry for that
 func DecodeAccessToken(accessToken string, e, n *string, expectedAudience string) (*jwt.Token, *jwt.MapClaims, error) {
 	const errMessage = "could not decode accessToken"
+	accessToken = strings.Replace(accessToken, "Bearer ", "", 1)
 
 	rsaPublicKey, err := decodePublicKey(e, n)
 	if err != nil {
@@ -108,6 +109,7 @@ func DecodeAccessToken(accessToken string, e, n *string, expectedAudience string
 // DecodeAccessTokenCustomClaims currently only supports RSA - sorry for that
 func DecodeAccessTokenCustomClaims(accessToken string, e, n *string, customClaims jwt.Claims, expectedAudience string) (*jwt.Token, error) {
 	const errMessage = "could not decode accessToken with custom claims"
+	accessToken = strings.Replace(accessToken, "Bearer ", "", 1)
 
 	rsaPublicKey, err := decodePublicKey(e, n)
 	if err != nil {


### PR DESCRIPTION
fixes (#238)

To prevent breaking changes, i added the removal to each public function that handles the token (from header).
Well, that is probably redundant, but neccessary for an improved workflow.
