### PR TITLE
Stringer

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,5 +387,53 @@ docker stop gocloak-test
 docker rm gocloak-test
 ```
 
+### Inspecting custom types
+
+The custom types contain many pointers, so printing them yields mostly pointer values, which aren't much help when debugging your application. For example
+
+```
+someRealmRepresentation := gocloak.RealmRepresentation{
+   <snip>
+}
+
+fmt.Println(someRealmRepresentation)
+
+```
+yields a large set of pointer values
+```
+{<nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> 0xc00000e960 <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> 0xc000093cf0 <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> null <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil>}
+```
+For convenience, the ```String()``` interface has been added so you can easily see the contents, even for nested custom types. For example,
+
+```
+fmt.Println(someRealmRepresentation.String())
+```
+yields
+
+```
+{
+	"clients": [
+		{
+			"name": "someClient",
+			"protocolMappers": [
+				{
+					"config": {
+						"bar": "foo",
+						"ping": "pong"
+					},
+					"name": "someMapper"
+				}
+			]
+		},
+		{
+			"name": "AnotherClient"
+		}
+	],
+	"displayName": "someRealm"
+}
+```
+Note that empty parameters are not included, because of the use of ```omitempty``` in the type definitions.
+
+
 ## License
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2FNerzal%2Fgocloak.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2FNerzal%2Fgocloak?ref=badge_large)

--- a/README.md
+++ b/README.md
@@ -108,6 +108,11 @@ go get github.com/Nerzal/gocloak/v7
 ```go
 // GoCloak holds all methods a client should fulfill
 type GoCloak interface {
+
+	RestyClient() *resty.Client
+	SetRestyClient(restyClient *resty.Client)
+
+	GetToken(ctx context.Context, realm string, options TokenOptions) (*JWT, error)
 	GetRequestingPartyToken(ctx context.Context, token, realm string, options RequestingPartyTokenOptions) (*JWT, error)
 	GetRequestingPartyPermissions(ctx context.Context, token, realm string, options RequestingPartyTokenOptions) (*[]RequestingPartyPermission, error)
 
@@ -120,7 +125,6 @@ type GoCloak interface {
 	LoginClient(ctx context.Context, clientID, clientSecret, realm string) (*JWT, error)
 	LoginClientSignedJWT(ctx context.Context, clientID, realm string, key interface{}, signedMethod jwt.SigningMethod, expiresAt *jwt.Time) (*JWT, error)
 	LoginAdmin(ctx context.Context, username, password, realm string) (*JWT, error)
-	RequestPermission(ctx context.Context, clientID, clientSecret, realm, username, password, permission string) (*JWT, error)
 	RefreshToken(ctx context.Context, refreshToken, clientID, clientSecret, realm string) (*JWT, error)
 	DecodeAccessToken(ctx context.Context, accessToken, realm, expectedAudience string) (*jwt.Token, *jwt.MapClaims, error)
 	DecodeAccessTokenCustomClaims(ctx context.Context, accessToken, realm, expectedAudience string, claims jwt.Claims) (*jwt.Token, error)
@@ -153,6 +157,7 @@ type GoCloak interface {
 	DeleteComponent(ctx context.Context, accessToken, realm, componentID string) error
 	DeleteGroup(ctx context.Context, accessToken, realm, groupID string) error
 	DeleteClientRole(ctx context.Context, accessToken, realm, clientID, roleName string) error
+	DeleteClientRoleFromUser(ctx context.Context, token, realm, clientID, userID string, roles []Role) error
 	DeleteClient(ctx context.Context, accessToken, realm, clientID string) error
 	DeleteClientScope(ctx context.Context, accessToken, realm, scopeID string) error
 	DeleteClientScopeMappingsRealmRoles(ctx context.Context, token, realm, clientID string, roles []Role) error
@@ -183,6 +188,7 @@ type GoCloak interface {
 	GetUsers(ctx context.Context, accessToken, realm string, params GetUsersParams) ([]*User, error)
 	GetUserGroups(ctx context.Context, accessToken, realm, userID string, params GetGroupsParams) ([]*UserGroup, error)
 	AddUserToGroup(ctx context.Context, token, realm, userID, groupID string) error
+	DeleteUserFromGroup(ctx context.Context, token, realm, userID, groupID string) error
 	GetComponents(ctx context.Context, accessToken, realm string) ([]*Component, error)
 	GetGroups(ctx context.Context, accessToken, realm string, params GetGroupsParams) ([]*Group, error)
 	GetGroupsCount(ctx context.Context, token, realm string, params GetGroupsParams) (int, error)
@@ -195,6 +201,7 @@ type GoCloak interface {
 	GetRoleMappingByUserID(ctx context.Context, accessToken, realm, userID string) (*MappingsRepresentation, error)
 	GetClientRoles(ctx context.Context, accessToken, realm, clientID string) ([]*Role, error)
 	GetClientRole(ctx context.Context, token, realm, clientID, roleName string) (*Role, error)
+	GetClientRoleByID(ctx context.Context, accessToken, realm, roleID string) (*Role, error)
 	GetClients(ctx context.Context, accessToken, realm string, params GetClientsParams) ([]*Client, error)
 	AddClientRoleComposite(ctx context.Context, token, realm, roleID string, roles []Role) error
 	DeleteClientRoleComposite(ctx context.Context, token, realm, roleID string, roles []Role) error
@@ -227,6 +234,7 @@ type GoCloak interface {
 
 	// *** Client Roles ***
 
+	AddClientRoleToUser(ctx context.Context, token, realm, clientID, userID string, roles []Role) error
 	AddClientRoleToGroup(ctx context.Context, token, realm, clientID, groupID string, roles []Role) error
 	DeleteClientRoleFromGroup(ctx context.Context, token, realm, clientID, groupID string, roles []Role) error
 	GetCompositeClientRolesByRoleID(ctx context.Context, token, realm, clientID, roleID string) ([]*Role, error)
@@ -259,7 +267,7 @@ type GoCloak interface {
 	CreateResource(ctx context.Context, token, realm, clientID string, resource ResourceRepresentation) (*ResourceRepresentation, error)
 	UpdateResource(ctx context.Context, token, realm, clientID string, resource ResourceRepresentation) error
 	DeleteResource(ctx context.Context, token, realm, clientID, resourceID string) error
-	
+
 	GetResourceClient(ctx context.Context, token, realm, resourceID string) (*ResourceRepresentation, error)
 	GetResourcesClient(ctx context.Context, token, realm string, params GetResourceParams) ([]*ResourceRepresentation, error)
 	CreateResourceClient(ctx context.Context, token, realm string, resource ResourceRepresentation) (*ResourceRepresentation, error)
@@ -278,7 +286,6 @@ type GoCloak interface {
 	UpdatePolicy(ctx context.Context, token, realm, clientID string, policy PolicyRepresentation) error
 	DeletePolicy(ctx context.Context, token, realm, clientID, policyID string) error
 
-
 	GetResourcePolicy(ctx context.Context, token, realm, permissionID string) (*ResourcePolicyRepresentation, error) 
 	GetResourcePolicies(ctx context.Context, token, realm string, params GetResourcePoliciesParams) ([]*ResourcePolicyRepresentation, error) 
 	CreateResourcePolicy(ctx context.Context, token, realm, resourceID string, policy ResourcePolicyRepresentation) (*ResourcePolicyRepresentation, error) 
@@ -287,16 +294,19 @@ type GoCloak interface {
 
 	GetPermission(ctx context.Context, token, realm, clientID, permissionID string) (*PermissionRepresentation, error)
 	GetPermissions(ctx context.Context, token, realm, clientID string, params GetPermissionParams) ([]*PermissionRepresentation, error)
+	GetPermissionResources(ctx context.Context, token, realm, clientID, permissionID string) ([]*PermissionResource, error)
+	GetPermissionScopes(ctx context.Context, token, realm, clientID, permissionID string) ([]*PermissionScope, error)
+	GetDependentPermissions(ctx context.Context, token, realm, clientID, policyID string) ([]*PermissionRepresentation, error)
 	CreatePermission(ctx context.Context, token, realm, clientID string, permission PermissionRepresentation) (*PermissionRepresentation, error)
 	UpdatePermission(ctx context.Context, token, realm, clientID string, permission PermissionRepresentation) error
 	DeletePermission(ctx context.Context, token, realm, clientID, permissionID string) error
-	
+
 	CreatePermissionTicket(ctx context.Context, token, realm string, permissions []CreatePermissionTicketParams) (*PermissionTicketResponseRepresentation, error)
 	GrantUserPermission(ctx context.Context, token, realm string, permission PermissionGrantParams) (*PermissionGrantResponseRepresentation, error)
 	UpdateUserPermission(ctx context.Context, token, realm string, permission PermissionGrantParams) (*PermissionGrantResponseRepresentation, error)
 	GetUserPermissions(ctx context.Context, token, realm string, params GetUserPermissionParams) ([]*PermissionGrantResponseRepresentation, error)
 	DeleteUserPermission(ctx context.Context, token, realm, ticketID string) error
-	
+
 	// *** Credentials API ***
 
 	GetCredentialRegistrators(ctx context.Context, token, realm string) ([]string, error)
@@ -307,6 +317,19 @@ type GoCloak interface {
 	DisableAllCredentialsByType(ctx context.Context, token, realm, userID string, types []string) error
 	MoveCredentialBehind(ctx context.Context, token, realm, userID, credentialID, newPreviousCredentialID string) error
 	MoveCredentialToFirst(ctx context.Context, token, realm, userID, credentialID string) error
+
+	// *** Identity Providers ***
+
+	CreateIdentityProvider(ctx context.Context, token, realm string, providerRep IdentityProviderRepresentation) (string, error)
+	GetIdentityProvider(ctx context.Context, token, realm, alias string) (*IdentityProviderRepresentation, error)
+	GetIdentityProviders(ctx context.Context, token, realm string) ([]*IdentityProviderRepresentation, error)
+	UpdateIdentityProvider(ctx context.Context, token, realm, alias string, providerRep IdentityProviderRepresentation) error
+	DeleteIdentityProvider(ctx context.Context, token, realm, alias string) error
+
+	CreateUserFederatedIdentity(ctx context.Context, token, realm, userID, providerID string, federatedIdentityRep FederatedIdentityRepresentation) error
+	GetUserFederatedIdentities(ctx context.Context, token, realm, userID string) ([]*FederatedIdentityRepresentation, error)
+	DeleteUserFederatedIdentity(ctx context.Context, token, realm, userID, providerID string) error
+
 }
 ```
 

--- a/model_test.go
+++ b/model_test.go
@@ -204,3 +204,120 @@ func TestStringer(t *testing.T) {
 	assert.Equal(t, expectedStr, str)
 
 }
+
+type Stringable interface {
+	String() string
+}
+
+func TestStringerOmitEmpty(t *testing.T) {
+
+	customs := []Stringable{
+		&gocloak.CertResponseKey{},
+		&gocloak.CertResponse{},
+		&gocloak.IssuerResponse{},
+		&gocloak.ResourcePermission{},
+		&gocloak.PermissionResource{},
+		&gocloak.PermissionScope{},
+		&gocloak.RetrospecTokenResult{},
+		&gocloak.User{},
+		&gocloak.SetPasswordRequest{},
+		&gocloak.Component{},
+		&gocloak.ComponentConfig{},
+		&gocloak.KeyStoreConfig{},
+		&gocloak.ActiveKeys{},
+		&gocloak.Key{},
+		&gocloak.Attributes{},
+		&gocloak.Access{},
+		&gocloak.UserGroup{},
+		&gocloak.ExecuteActionsEmail{},
+		&gocloak.Group{},
+		&gocloak.GroupsCount{},
+		&gocloak.GetGroupsParams{},
+		&gocloak.CompositesRepresentation{},
+		&gocloak.Role{},
+		&gocloak.ClientMappingsRepresentation{},
+		&gocloak.MappingsRepresentation{},
+		&gocloak.ClientScope{},
+		&gocloak.ClientScopeAttributes{},
+		&gocloak.ProtocolMappers{},
+		&gocloak.ProtocolMappersConfig{},
+		&gocloak.Client{},
+		&gocloak.ResourceServerRepresentation{},
+		&gocloak.RoleDefinition{},
+		&gocloak.PolicyRepresentation{},
+		&gocloak.RolePolicyRepresentation{},
+		&gocloak.JSPolicyRepresentation{},
+		&gocloak.ClientPolicyRepresentation{},
+		&gocloak.TimePolicyRepresentation{},
+		&gocloak.UserPolicyRepresentation{},
+		&gocloak.AggregatedPolicyRepresentation{},
+		&gocloak.GroupPolicyRepresentation{},
+		&gocloak.GroupDefinition{},
+		&gocloak.ResourceRepresentation{},
+		&gocloak.ResourceOwnerRepresentation{},
+		&gocloak.ScopeRepresentation{},
+		&gocloak.ProtocolMapperRepresentation{},
+		&gocloak.UserInfoAddress{},
+		&gocloak.UserInfo{},
+		&gocloak.RolesRepresentation{},
+		&gocloak.RealmRepresentation{},
+		&gocloak.MultiValuedHashMap{},
+		&gocloak.TokenOptions{},
+		&gocloak.UserSessionRepresentation{},
+		&gocloak.SystemInfoRepresentation{},
+		&gocloak.MemoryInfoRepresentation{},
+		&gocloak.ServerInfoRepesentation{},
+		&gocloak.FederatedIdentityRepresentation{},
+		&gocloak.IdentityProviderRepresentation{},
+		&gocloak.GetResourceParams{},
+		&gocloak.GetScopeParams{},
+		&gocloak.GetPolicyParams{},
+		&gocloak.GetPermissionParams{},
+		&gocloak.GetUsersByRoleParams{},
+		&gocloak.PermissionRepresentation{},
+		&gocloak.CreatePermissionTicketParams{},
+		&gocloak.PermissionTicketDescriptionRepresentation{},
+		&gocloak.AccessRepresentation{},
+		&gocloak.PermissionTicketResponseRepresentation{},
+		&gocloak.PermissionTicketRepresentation{},
+		&gocloak.PermissionTicketPermissionRepresentation{},
+		&gocloak.PermissionGrantParams{},
+		&gocloak.PermissionGrantResponseRepresentation{},
+		&gocloak.GetUserPermissionParams{},
+		&gocloak.ResourcePolicyRepresentation{},
+		&gocloak.GetResourcePoliciesParams{},
+		&gocloak.CredentialRepresentation{},
+	}
+
+	for _, custom := range customs {
+
+		assert.Equal(t, "{}", custom.(Stringable).String())
+	}
+
+	extras := make(map[Stringable]string)
+
+	extras[&gocloak.GetUsersParams{}] = `{
+	"briefRepresentation": null
+}`
+
+	extras[&gocloak.GetUsersParams{}] = `{
+	"briefRepresentation": null
+}`
+
+	extras[&gocloak.GetClientsParams{}] = `{
+	"viewableOnly": null
+}`
+
+	extras[&gocloak.RequestingPartyTokenOptions{}] = `{
+	"response_include_resource_name": null
+}`
+	extras[&gocloak.RequestingPartyPermission{}] = `{
+	"scopes": null
+}`
+
+	for k, exp := range extras {
+
+		assert.Equal(t, exp, k.String())
+	}
+
+}

--- a/model_test.go
+++ b/model_test.go
@@ -287,37 +287,15 @@ func TestStringerOmitEmpty(t *testing.T) {
 		&gocloak.ResourcePolicyRepresentation{},
 		&gocloak.GetResourcePoliciesParams{},
 		&gocloak.CredentialRepresentation{},
+		&gocloak.GetUsersParams{},
+		&gocloak.GetClientsParams{},
+		&gocloak.RequestingPartyTokenOptions{},
+		&gocloak.RequestingPartyPermission{},
 	}
 
 	for _, custom := range customs {
 
 		assert.Equal(t, "{}", custom.(Stringable).String())
-	}
-
-	extras := make(map[Stringable]string)
-
-	extras[&gocloak.GetUsersParams{}] = `{
-	"briefRepresentation": null
-}`
-
-	extras[&gocloak.GetUsersParams{}] = `{
-	"briefRepresentation": null
-}`
-
-	extras[&gocloak.GetClientsParams{}] = `{
-	"viewableOnly": null
-}`
-
-	extras[&gocloak.RequestingPartyTokenOptions{}] = `{
-	"response_include_resource_name": null
-}`
-	extras[&gocloak.RequestingPartyPermission{}] = `{
-	"scopes": null
-}`
-
-	for k, exp := range extras {
-
-		assert.Equal(t, exp, k.String())
 	}
 
 }

--- a/model_test.go
+++ b/model_test.go
@@ -120,3 +120,87 @@ func TestParseAPIErrType(t *testing.T) {
 		})
 	}
 }
+
+func TestStringer(t *testing.T) {
+	//nested structs
+	actions := []string{"someAction", "anotherAction"}
+	access := gocloak.AccessRepresentation{
+		Manage:      gocloak.BoolP(true),
+		Impersonate: gocloak.BoolP(false),
+	}
+	v := gocloak.PermissionTicketDescriptionRepresentation{
+		ID:               gocloak.StringP("someID"),
+		CreatedTimeStamp: gocloak.Int64P(1607702613),
+		Enabled:          gocloak.BoolP(true),
+		RequiredActions:  &actions,
+		Access:           &access,
+	}
+
+	str := v.String()
+
+	expectedStr := `{
+	"id": "someID",
+	"createdTimestamp": 1607702613,
+	"enabled": true,
+	"requiredActions": [
+		"someAction",
+		"anotherAction"
+	],
+	"access": {
+		"impersonate": false,
+		"manage": true
+	}
+}`
+
+	assert.Equal(t, expectedStr, str)
+
+	// nested arrays
+	config := make(map[string]string)
+	config["bar"] = "foo"
+	config["ping"] = "pong"
+
+	pmappers := []gocloak.ProtocolMapperRepresentation{
+		{
+			Name:   gocloak.StringP("someMapper"),
+			Config: &config,
+		},
+	}
+	clients := []gocloak.Client{
+		{
+			Name:            gocloak.StringP("someClient"),
+			ProtocolMappers: &pmappers,
+		},
+		{
+			Name: gocloak.StringP("AnotherClient"),
+		},
+	}
+
+	realmRep := gocloak.RealmRepresentation{
+		DisplayName: gocloak.StringP("someRealm"),
+		Clients:     &clients,
+	}
+
+	str = realmRep.String()
+	expectedStr = `{
+	"clients": [
+		{
+			"name": "someClient",
+			"protocolMappers": [
+				{
+					"config": {
+						"bar": "foo",
+						"ping": "pong"
+					},
+					"name": "someMapper"
+				}
+			]
+		},
+		{
+			"name": "AnotherClient"
+		}
+	],
+	"displayName": "someRealm"
+}`
+	assert.Equal(t, expectedStr, str)
+
+}

--- a/models.go
+++ b/models.go
@@ -1127,7 +1127,7 @@ func (v *GetUsersParams) String() string                            { return pre
 func (v *ExecuteActionsEmail) String() string                       { return prettyStringStruct(v) }
 func (v *Group) String() string                                     { return prettyStringStruct(v) }
 func (v *GroupsCount) String() string                               { return prettyStringStruct(v) }
-func (v *GetGroupsParams) String() string                           { return prettyStringStruct(v) }
+func (obj *GetGroupsParams) String() string                         { return prettyStringStruct(obj) }
 func (v *CompositesRepresentation) String() string                  { return prettyStringStruct(v) }
 func (v *Role) String() string                                      { return prettyStringStruct(v) }
 func (v *ClientMappingsRepresentation) String() string              { return prettyStringStruct(v) }
@@ -1158,8 +1158,8 @@ func (v *UserInfo) String() string                                  { return pre
 func (v *RolesRepresentation) String() string                       { return prettyStringStruct(v) }
 func (v *RealmRepresentation) String() string                       { return prettyStringStruct(v) }
 func (v *MultiValuedHashMap) String() string                        { return prettyStringStruct(v) }
-func (v *TokenOptions) String() string                              { return prettyStringStruct(v) }
-func (v *RequestingPartyTokenOptions) String() string               { return prettyStringStruct(v) }
+func (t *TokenOptions) String() string                              { return prettyStringStruct(t) }
+func (t *RequestingPartyTokenOptions) String() string               { return prettyStringStruct(t) }
 func (v *RequestingPartyPermission) String() string                 { return prettyStringStruct(v) }
 func (v *UserSessionRepresentation) String() string                 { return prettyStringStruct(v) }
 func (v *SystemInfoRepresentation) String() string                  { return prettyStringStruct(v) }

--- a/models.go
+++ b/models.go
@@ -1093,3 +1093,95 @@ type CredentialRepresentation struct {
 	SecretData     *string `json:"secretData,omitempty"`
 	UserLabel      *string `json:"userLabel,omitempty"`
 }
+
+// prettyStringStruct returns struct formatted into pretty string
+func prettyStringStruct(t interface{}) string {
+
+	json, err := json.MarshalIndent(t, "", "\t")
+	if err != nil {
+		return ""
+	}
+
+	return string(json)
+}
+
+// Stringer implementations for all struct types
+func (v *CertResponseKey) String() string                           { return prettyStringStruct(v) }
+func (v *CertResponse) String() string                              { return prettyStringStruct(v) }
+func (v *IssuerResponse) String() string                            { return prettyStringStruct(v) }
+func (v *ResourcePermission) String() string                        { return prettyStringStruct(v) }
+func (v *PermissionResource) String() string                        { return prettyStringStruct(v) }
+func (v *PermissionScope) String() string                           { return prettyStringStruct(v) }
+func (v *RetrospecTokenResult) String() string                      { return prettyStringStruct(v) }
+func (v *User) String() string                                      { return prettyStringStruct(v) }
+func (v *SetPasswordRequest) String() string                        { return prettyStringStruct(v) }
+func (v *Component) String() string                                 { return prettyStringStruct(v) }
+func (v *ComponentConfig) String() string                           { return prettyStringStruct(v) }
+func (v *KeyStoreConfig) String() string                            { return prettyStringStruct(v) }
+func (v *ActiveKeys) String() string                                { return prettyStringStruct(v) }
+func (v *Key) String() string                                       { return prettyStringStruct(v) }
+func (v *Attributes) String() string                                { return prettyStringStruct(v) }
+func (v *Access) String() string                                    { return prettyStringStruct(v) }
+func (v *UserGroup) String() string                                 { return prettyStringStruct(v) }
+func (v *GetUsersParams) String() string                            { return prettyStringStruct(v) }
+func (v *ExecuteActionsEmail) String() string                       { return prettyStringStruct(v) }
+func (v *Group) String() string                                     { return prettyStringStruct(v) }
+func (v *GroupsCount) String() string                               { return prettyStringStruct(v) }
+func (v *GetGroupsParams) String() string                           { return prettyStringStruct(v) }
+func (v *CompositesRepresentation) String() string                  { return prettyStringStruct(v) }
+func (v *Role) String() string                                      { return prettyStringStruct(v) }
+func (v *ClientMappingsRepresentation) String() string              { return prettyStringStruct(v) }
+func (v *MappingsRepresentation) String() string                    { return prettyStringStruct(v) }
+func (v *ClientScope) String() string                               { return prettyStringStruct(v) }
+func (v *ClientScopeAttributes) String() string                     { return prettyStringStruct(v) }
+func (v *ProtocolMappers) String() string                           { return prettyStringStruct(v) }
+func (v *ProtocolMappersConfig) String() string                     { return prettyStringStruct(v) }
+func (v *Client) String() string                                    { return prettyStringStruct(v) }
+func (v *ResourceServerRepresentation) String() string              { return prettyStringStruct(v) }
+func (v *RoleDefinition) String() string                            { return prettyStringStruct(v) }
+func (v *PolicyRepresentation) String() string                      { return prettyStringStruct(v) }
+func (v *RolePolicyRepresentation) String() string                  { return prettyStringStruct(v) }
+func (v *JSPolicyRepresentation) String() string                    { return prettyStringStruct(v) }
+func (v *ClientPolicyRepresentation) String() string                { return prettyStringStruct(v) }
+func (v *TimePolicyRepresentation) String() string                  { return prettyStringStruct(v) }
+func (v *UserPolicyRepresentation) String() string                  { return prettyStringStruct(v) }
+func (v *AggregatedPolicyRepresentation) String() string            { return prettyStringStruct(v) }
+func (v *GroupPolicyRepresentation) String() string                 { return prettyStringStruct(v) }
+func (v *GroupDefinition) String() string                           { return prettyStringStruct(v) }
+func (v *ResourceRepresentation) String() string                    { return prettyStringStruct(v) }
+func (v *ResourceOwnerRepresentation) String() string               { return prettyStringStruct(v) }
+func (v *ScopeRepresentation) String() string                       { return prettyStringStruct(v) }
+func (v *ProtocolMapperRepresentation) String() string              { return prettyStringStruct(v) }
+func (v *GetClientsParams) String() string                          { return prettyStringStruct(v) }
+func (v *UserInfoAddress) String() string                           { return prettyStringStruct(v) }
+func (v *UserInfo) String() string                                  { return prettyStringStruct(v) }
+func (v *RolesRepresentation) String() string                       { return prettyStringStruct(v) }
+func (v *RealmRepresentation) String() string                       { return prettyStringStruct(v) }
+func (v *MultiValuedHashMap) String() string                        { return prettyStringStruct(v) }
+func (v *TokenOptions) String() string                              { return prettyStringStruct(v) }
+func (v *RequestingPartyTokenOptions) String() string               { return prettyStringStruct(v) }
+func (v *RequestingPartyPermission) String() string                 { return prettyStringStruct(v) }
+func (v *UserSessionRepresentation) String() string                 { return prettyStringStruct(v) }
+func (v *SystemInfoRepresentation) String() string                  { return prettyStringStruct(v) }
+func (v *MemoryInfoRepresentation) String() string                  { return prettyStringStruct(v) }
+func (v *ServerInfoRepesentation) String() string                   { return prettyStringStruct(v) }
+func (v *FederatedIdentityRepresentation) String() string           { return prettyStringStruct(v) }
+func (v *IdentityProviderRepresentation) String() string            { return prettyStringStruct(v) }
+func (v *GetResourceParams) String() string                         { return prettyStringStruct(v) }
+func (v *GetScopeParams) String() string                            { return prettyStringStruct(v) }
+func (v *GetPolicyParams) String() string                           { return prettyStringStruct(v) }
+func (v *GetPermissionParams) String() string                       { return prettyStringStruct(v) }
+func (v *GetUsersByRoleParams) String() string                      { return prettyStringStruct(v) }
+func (v *PermissionRepresentation) String() string                  { return prettyStringStruct(v) }
+func (v *CreatePermissionTicketParams) String() string              { return prettyStringStruct(v) }
+func (v *PermissionTicketDescriptionRepresentation) String() string { return prettyStringStruct(v) }
+func (v *AccessRepresentation) String() string                      { return prettyStringStruct(v) }
+func (v *PermissionTicketResponseRepresentation) String() string    { return prettyStringStruct(v) }
+func (v *PermissionTicketRepresentation) String() string            { return prettyStringStruct(v) }
+func (v *PermissionTicketPermissionRepresentation) String() string  { return prettyStringStruct(v) }
+func (v *PermissionGrantParams) String() string                     { return prettyStringStruct(v) }
+func (v *PermissionGrantResponseRepresentation) String() string     { return prettyStringStruct(v) }
+func (v *GetUserPermissionParams) String() string                   { return prettyStringStruct(v) }
+func (v *ResourcePolicyRepresentation) String() string              { return prettyStringStruct(v) }
+func (v *GetResourcePoliciesParams) String() string                 { return prettyStringStruct(v) }
+func (v *CredentialRepresentation) String() string                  { return prettyStringStruct(v) }

--- a/models.go
+++ b/models.go
@@ -261,7 +261,7 @@ type UserGroup struct {
 
 // GetUsersParams represents the optional parameters for getting users
 type GetUsersParams struct {
-	BriefRepresentation *bool   `json:"briefRepresentation,string"`
+	BriefRepresentation *bool   `json:"briefRepresentation,string,omitempty"`
 	Email               *string `json:"email,omitempty"`
 	Enabled             *bool   `json:"enabled,string,omitempty"`
 	Exact               *bool   `json:"exact,string,omitempty"`
@@ -602,7 +602,7 @@ type ProtocolMapperRepresentation struct {
 // GetClientsParams represents the query parameters
 type GetClientsParams struct {
 	ClientID     *string `json:"clientId,omitempty"`
-	ViewableOnly *bool   `json:"viewableOnly,string"`
+	ViewableOnly *bool   `json:"viewableOnly,string,omitempty"`
 }
 
 // UserInfoAddress is representation of the address sub-filed of UserInfo
@@ -795,7 +795,7 @@ type RequestingPartyTokenOptions struct {
 	RPT                         *string   `json:"rpt,omitempty"`
 	Permissions                 *[]string `json:"-"`
 	Audience                    *string   `json:"audience,omitempty"`
-	ResponseIncludeResourceName *bool     `json:"response_include_resource_name,string"`
+	ResponseIncludeResourceName *bool     `json:"response_include_resource_name,string,omitempty"`
 	ResponsePermissionsLimit    *uint32   `json:"response_permissions_limit,omitempty"`
 	SubmitRequest               *bool     `json:"submit_request,string,omitempty"`
 	ResponseMode                *string   `json:"response_mode,omitempty"`
@@ -821,7 +821,7 @@ type RequestingPartyPermission struct {
 	Claims       *map[string]string `json:"claims,omitempty"`
 	ResourceID   *string            `json:"rsid,omitempty"`
 	ResourceName *string            `json:"rsname,omitempty"`
-	Scopes       *[]string          `json:"scopes"`
+	Scopes       *[]string          `json:"scopes,omitempty"`
 }
 
 // UserSessionRepresentation represents a list of user's sessions


### PR DESCRIPTION
Implements Issue #243 , providing String() for each of the custom types, via ```json.MarshalIndent```. The code format is one-line for ease of future maintenance (e.g. using emacs column mode) but happy to format to multiline if you would prefer that. I also swithered for a moment over indent or not, but since indent is usually what I use for debugging, and this is not really a feature for production where compact string representations are needed, I decided not to implement multiple formats.