### PR TITLE
Changes returntype of GetUserGroups to Group

### DIFF
--- a/client.go
+++ b/client.go
@@ -1972,10 +1972,10 @@ func (client *gocloak) GetUserCount(ctx context.Context, token string, realm str
 }
 
 // GetUserGroups get all groups for user
-func (client *gocloak) GetUserGroups(ctx context.Context, token, realm, userID string, params GetGroupsParams) ([]*UserGroup, error) {
+func (client *gocloak) GetUserGroups(ctx context.Context, token, realm, userID string, params GetGroupsParams) ([]*Group, error) {
 	const errMessage = "could not get user groups"
 
-	var result []*UserGroup
+	var result []*Group
 	queryParams, err := GetQueryParams(params)
 	if err != nil {
 		return nil, errors.Wrap(err, errMessage)

--- a/gocloak.go
+++ b/gocloak.go
@@ -281,7 +281,7 @@ type GoCloak interface {
 	// GetUsers gets all users of the given realm
 	GetUsers(ctx context.Context, accessToken, realm string, params GetUsersParams) ([]*User, error)
 	// GetUserGroups gets the groups of the given user
-	GetUserGroups(ctx context.Context, accessToken, realm, userID string, params GetGroupsParams) ([]*UserGroup, error)
+	GetUserGroups(ctx context.Context, accessToken, realm, userID string, params GetGroupsParams) ([]*Group, error)
 	// GetUsersByRoleName returns all users have a given role
 	GetUsersByRoleName(ctx context.Context, token, realm, roleName string) ([]*User, error)
 	// GetUsersByClientRoleName returns all users have a given client role


### PR DESCRIPTION
Closes #245 

This allows full context querys with Briefrepresentation = false for
UserGroups. No additional config required, since Group is configured
with omitempty json tags.

Thanks for your contribution!
Hi, if there is an issue, that your PR adresses, please link it! 
