### PR TITLE
added `first` & `max` to client query parameters to support pagination

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -5273,3 +5273,35 @@ func TestGocloak_TestSetFunctionalOptions(t *testing.T) {
 	cfg := GetConfig(t)
 	gocloak.NewClient(cfg.HostName, gocloak.SetAuthRealms("foo"), gocloak.SetAuthAdminRealms("bar"))
 }
+
+func TestGocloak_GetClientsWithPagination(t *testing.T) {
+	cfg := GetConfig(t)
+	client := NewClientWithDebug(t)
+	token := GetAdminToken(t, client)
+	clientID := GetRandomNameP("ClientID")
+
+	testClient := gocloak.Client{
+		ClientID: clientID,
+		BaseURL:  gocloak.StringP("http://example.com"),
+	}
+	t.Logf("Client ID: %s", *clientID)
+
+	// Creating a client
+	tearDown, createdClientID := CreateClient(t, client, &testClient)
+	defer tearDown()
+	t.Log(createdClientID)
+	first := 0
+	max := 1
+	// Looking for a created client
+	clients, err := client.GetClients(
+		context.Background(),
+		token.AccessToken,
+		cfg.GoCloak.Realm,
+		gocloak.GetClientsParams{
+			First: &first,
+			Max:   &max,
+		},
+	)
+	require.NoError(t, err)
+	require.Equal(t, max, len(clients))
+}

--- a/models.go
+++ b/models.go
@@ -603,6 +603,8 @@ type ProtocolMapperRepresentation struct {
 type GetClientsParams struct {
 	ClientID     *string `json:"clientId,omitempty"`
 	ViewableOnly *bool   `json:"viewableOnly,string,omitempty"`
+	First        *int    `json:"first,string,omitempty"`
+	Max          *int    `json:"max,string,omitempty"`
 }
 
 // UserInfoAddress is representation of the address sub-filed of UserInfo


### PR DESCRIPTION
added `first` & `max` to client query parameters to support pagination for the GetClients call.

Keycloak admin API supports pagination for fetching the clients
eg:-
```http://localhost:$PORT/auth/admin/realms/$REALM/clients?first=0&max=10"```

