### PR TITLE
implemented crud for authentication flows and executions

### DIFF
--- a/client.go
+++ b/client.go
@@ -1902,6 +1902,81 @@ func (client *gocloak) ClearKeysCache(ctx context.Context, token, realm string) 
 	return checkForError(resp, err, errMessage)
 }
 
+//GetAuthenticationFlows get all authentication flows from a realm
+func (client *gocloak) GetAuthenticationFlows(ctx context.Context, token, realm string) ([]*AuthenticationFlowRepresentation, error) {
+	const errMessage = "could not retrieve authentication flows"
+	var result []*AuthenticationFlowRepresentation
+	resp, err := client.getRequestWithBearerAuth(ctx, token).
+		SetResult(&result).
+		Get(client.getAdminRealmURL(realm, "authentication", "flows"))
+
+	if err := checkForError(resp, err, errMessage); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+//Create a new Authentication flow in a realm
+func (client *gocloak) CreateAuthenticationFlow(ctx context.Context, token, realm string, flow AuthenticationFlowRepresentation) error {
+	const errMessage = "could not create authentication flows"
+	var result []*AuthenticationFlowRepresentation
+	resp, err := client.getRequestWithBearerAuth(ctx, token).
+		SetResult(&result).SetBody(flow).
+		Post(client.getAdminRealmURL(realm, "authentication", "flows"))
+
+	return checkForError(resp, err, errMessage)
+}
+
+//DeleteAuthenticationFlow deletes a flow in a realm with the given ID
+func (client *gocloak) DeleteAuthenticationFlow(ctx context.Context, token, realm, flowID string) error {
+	const errMessage = "could not delete authentication flows"
+	resp, err := client.getRequestWithBearerAuth(ctx, token).
+		Delete(client.getAdminRealmURL(realm, "authentication", "flows", flowID))
+
+	return checkForError(resp, err, errMessage)
+}
+
+//GetAuthenticationExecutions retrieves all executions of a given flow
+func (client *gocloak) GetAuthenticationExecutions(ctx context.Context, token, realm, flow string) ([]*ModifyAuthenticationExecutionRepresentation, error) {
+	const errMessage = "could not retrieve authentication flows"
+	var result []*ModifyAuthenticationExecutionRepresentation
+	resp, err := client.getRequestWithBearerAuth(ctx, token).
+		SetResult(&result).
+		Get(client.getAdminRealmURL(realm, "authentication", "flows", flow, "executions"))
+
+	if err := checkForError(resp, err, errMessage); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+//CreateAuthenticationExecution creates a new execution for the given flow name in the given realm
+func (client *gocloak) CreateAuthenticationExecution(ctx context.Context, token, realm, flow string, execution CreateAuthenticationExecutionRepresentation) error {
+	const errMessage = "could not create authentication execution"
+	resp, err := client.getRequestWithBearerAuth(ctx, token).SetBody(execution).
+		Post(client.getAdminRealmURL(realm, "authentication", "flows", flow, "executions", "execution"))
+
+	return checkForError(resp, err, errMessage)
+}
+
+//UpdateAuthenticationExecution updates an authentication execution for the given flow in the given realm
+func (client *gocloak) UpdateAuthenticationExecution(ctx context.Context, token, realm, flow string, execution ModifyAuthenticationExecutionRepresentation) error {
+	const errMessage = "could not update authentication execution"
+	resp, err := client.getRequestWithBearerAuth(ctx, token).SetBody(execution).
+		Put(client.getAdminRealmURL(realm, "authentication", "flows", flow, "executions"))
+
+	return checkForError(resp, err, errMessage)
+}
+
+// DeleteAuthenticationExecution delete a single execution with the given ID
+func (client *gocloak) DeleteAuthenticationExecution(ctx context.Context, token, realm, executionID string) error {
+	const errMessage = "could not delete authentication execution"
+	resp, err := client.getRequestWithBearerAuth(ctx, token).
+		Delete(client.getAdminRealmURL(realm, "authentication", "executions", executionID))
+
+	return checkForError(resp, err, errMessage)
+}
+
 // -----
 // Users
 // -----

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Nerzal/gocloak/v8
+module github.com/alien0matic/gocloak/v8
 
 go 1.15
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/alien0matic/gocloak/v8
+module github.com/Nerzal/gocloak/v8
 
 go 1.15
 

--- a/gocloak.go
+++ b/gocloak.go
@@ -268,6 +268,20 @@ type GoCloak interface {
 	ClearUserCache(ctx context.Context, token, realm string) error
 	// ClearKeysCache clears realm cache
 	ClearKeysCache(ctx context.Context, token, realm string) error
+	//GetAuthenticationFlows get all authentication flows from a realm
+	GetAuthenticationFlows(ctx context.Context, token, realm string) ([]*AuthenticationFlowRepresentation, error)
+	//Create a new Authentication flow in a realm
+	CreateAuthenticationFlow(ctx context.Context, token, realm string, flow AuthenticationFlowRepresentation) error
+	//DeleteAuthenticationFlow deletes a flow in a realm with the given ID
+	DeleteAuthenticationFlow(ctx context.Context, token, realm, flowID string) error
+	//GetAuthenticationExecutions retrieves all executions of a given flow
+	GetAuthenticationExecutions(ctx context.Context, token, realm, flow string) ([]*ModifyAuthenticationExecutionRepresentation, error)
+	//CreateAuthenticationExecution creates a new execution for the given flow name in the given realm
+	CreateAuthenticationExecution(ctx context.Context, token, realm, flow string, execution CreateAuthenticationExecutionRepresentation) error
+	//UpdateAuthenticationExecution updates an authentication execution for the given flow in the given realm
+	UpdateAuthenticationExecution(ctx context.Context, token, realm, flow string, execution ModifyAuthenticationExecutionRepresentation) error
+	// DeleteAuthenticationExecution delete a single execution with the given ID
+	DeleteAuthenticationExecution(ctx context.Context, token, realm, executionID string) error
 
 	// *** Users ***
 	// CreateUser creates a new user

--- a/models.go
+++ b/models.go
@@ -745,6 +745,45 @@ type RealmRepresentation struct {
 	WaitIncrementSeconds                *int                 `json:"waitIncrementSeconds,omitempty"`
 }
 
+// AuthenticationFlowRepresentation represents an authentication flow of a realm
+type AuthenticationFlowRepresentation struct {
+	Alias                    *string                                  `json:"alias,omitempty"`
+	AuthenticationExecutions *[]AuthenticationExecutionRepresentation `json:"authenticationExecutions,omitempty"`
+	BuiltIn                  *bool                                    `json:"builtIn,omitempty"`
+	Description              *string                                  `json:"description,omitempty"`
+	ID                       *string                                  `json:"id,omitempty"`
+	ProviderID               *string                                  `json:"providerId,omitempty"`
+	TopLevel                 *bool                                    `json:"topLevel,omitempty"`
+}
+
+// AuthenticationExecutionRepresentation represents the authentication execution of an AuthenticationFlowRepresentation
+type AuthenticationExecutionRepresentation struct {
+	Authenticator       *string `json:"authenticator,omitempty"`
+	AuthenticatorConfig *string `json:"authenticatorConfig,omitempty"`
+	AuthenticatorFlow   *bool   `json:"authenticatorFlow,omitempty"`
+	AutheticatorFlow    *bool   `json:"autheticatorFlow,omitempty"`
+	FlowAlias           *string `json:"flowAlias,omitempty"`
+	Priority            *int    `json:"priority,omitempty"`
+	Requirement         *string `json:"requirement,omitempty"`
+	UserSetupAllowed    *bool   `json:"userSetupAllowed,omitempty"`
+}
+
+type CreateAuthenticationExecutionRepresentation struct {
+	Provider *string `json:"provider,omitempty"`
+}
+
+type ModifyAuthenticationExecutionRepresentation struct {
+	ID                  *string `json:"id,omitempty"`
+	Provider            *string `json:"providerId,omitempty"`
+	AuthenticatorConfig *string `json:"authenticatorConfig,omitempty"`
+	AuthenticatorFlow   *bool   `json:"authenticatorFlow,omitempty"`
+	AutheticatorFlow    *bool   `json:"autheticatorFlow,omitempty"`
+	FlowAlias           *string `json:"flowAlias,omitempty"`
+	Priority            *int    `json:"priority,omitempty"`
+	Requirement         *string `json:"requirement,omitempty"`
+	UserSetupAllowed    *bool   `json:"userSetupAllowed,omitempty"`
+}
+
 // MultiValuedHashMap represents something
 type MultiValuedHashMap struct {
 	Empty      *bool    `json:"empty,omitempty"`


### PR DESCRIPTION
Fixes #250

This is a first implementation for the creation and modification of authentication flows and executions. 
I'm sorry that the Models are such a mess, but that is what I reverse engineered from the keycloak admin console. You have different names for the same value in the authentication executions. It is provider on creation, providerId on getting/updating and authenticator when getting the authentication flow.
You also can't post a flow with all executions.