### PR TITLE
WIP: Fix client token related test failure

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -612,7 +612,8 @@ func TestGocloak_GetUserInfo(t *testing.T) {
 	t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
-	token := GetClientToken(t, client)
+	SetUpTestUser(t, client)
+	token := GetUserToken(t, client)
 	userInfo, err := client.GetUserInfo(
 		context.Background(),
 		token.AccessToken,
@@ -632,7 +633,8 @@ func TestGocloak_GetRawUserInfo(t *testing.T) {
 	t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
-	token := GetClientToken(t, client)
+	SetUpTestUser(t, client)
+	token := GetUserToken(t, client)
 	userInfo, err := client.GetUserInfo(
 		context.Background(),
 		token.AccessToken,
@@ -802,7 +804,8 @@ func TestGocloak_RefreshToken(t *testing.T) {
 	t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
-	token := GetClientToken(t, client)
+	SetUpTestUser(t, client)
+	token := GetUserToken(t, client)
 
 	token, err := client.RefreshToken(
 		context.Background(),


### PR DESCRIPTION
This PR should fix the tests that fail because of the breaking changes of keycloak 12. 

Tests broken include things that try to refresh a client token / or use a client token to grab _userinfo_. 

Approach to fix this is as opposed to using client token to test said things we use a user token to do the refresh and get info. 

I'm still having failures with getClientOfflineSessions and getClientUserSessions. Keycloak 500, both tests work fine if I run them individually but if I run all tests together they incur 500s. 