### PR TITLE
`TestGocloak_GetRawUserInfo` now tests `client.GetRawUserInfo` instead of `client.GetUserInfo`

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -633,7 +633,7 @@ func TestGocloak_GetRawUserInfo(t *testing.T) {
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetClientToken(t, client)
-	userInfo, err := client.GetUserInfo(
+	userInfo, err := client.GetRawUserInfo(
 		context.Background(),
 		token.AccessToken,
 		cfg.GoCloak.Realm,


### PR DESCRIPTION
`TestGocloak_GetRawUserInfo` now tests `client.GetRawUserInfo` instead of `client.GetUserInfo`

Both options only differ in the automatic unmarshalling target, but this fix was presumably intended.