### PR TITLE
added endpoint to support exporting public broker config info

### DIFF
--- a/client.go
+++ b/client.go
@@ -62,6 +62,12 @@ func (client *gocloak) getRequestWithBearerAuth(ctx context.Context, token strin
 		SetHeader("Content-Type", "application/json")
 }
 
+func (client *gocloak) getRequestWithBearerAuthXMLHeader(ctx context.Context, token string) *resty.Request {
+	return client.getRequest(ctx).
+		SetAuthToken(token).
+		SetHeader("Content-Type", "application/xml;charset=UTF-8")
+}
+
 func (client *gocloak) getRequestWithBasicAuth(ctx context.Context, clientID, clientSecret string) *resty.Request {
 	req := client.getRequest(ctx).
 		SetHeader("Content-Type", "application/x-www-form-urlencoded")
@@ -2303,6 +2309,21 @@ func (client *gocloak) DeleteIdentityProvider(ctx context.Context, token, realm,
 		Delete(client.getAdminRealmURL(realm, "identity-provider", "instances", alias))
 
 	return checkForError(resp, err, errMessage)
+}
+
+// ExportIDPPublicBrokerConfig exports the broker config for a given alias
+func (client *gocloak) ExportIDPPublicBrokerConfig(ctx context.Context, token, realm, alias string) (*string, error) {
+	const errMessage = "could not get public identity provider configuration"
+
+	resp, err := client.getRequestWithBearerAuthXMLHeader(ctx, token).
+		Get(client.getAdminRealmURL(realm, "identity-provider", "instances", alias, "export"))
+
+	if err := checkForError(resp, err, errMessage); err != nil {
+		return nil, err
+	}
+
+	result := resp.String()
+	return &result, nil
 }
 
 // ------------------

--- a/client_test.go
+++ b/client_test.go
@@ -3957,7 +3957,6 @@ func TestGocloak_CreateDeleteClientScopeWithMappers(t *testing.T) {
 // -----------------
 
 func TestGocloak_CreateProvider(t *testing.T) {
-	t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -4112,6 +4111,59 @@ func TestGocloak_CreateProvider(t *testing.T) {
 			token.AccessToken,
 			cfg.GoCloak.Realm,
 			"github",
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("create SAML provider", func(t *testing.T) {
+		repr := gocloak.IdentityProviderRepresentation{
+			Alias:                     gocloak.StringP("saml"),
+			DisplayName:               gocloak.StringP("Generic SAML"),
+			Enabled:                   gocloak.BoolP(true),
+			ProviderID:                gocloak.StringP("saml"),
+			TrustEmail:                gocloak.BoolP(true),
+			FirstBrokerLoginFlowAlias: gocloak.StringP("first broker login"),
+			Config: &map[string]string{
+				"singleSignOnServiceUrl": "https://samlIDPexample.com",
+			},
+		}
+		provider, err := client.CreateIdentityProvider(
+			context.Background(),
+			token.AccessToken,
+			cfg.GoCloak.Realm,
+			repr,
+		)
+		require.NoError(t, err)
+		require.Equal(t, "saml", provider)
+	})
+
+	t.Run("Get saml provider", func(t *testing.T) {
+		provider, err := client.GetIdentityProvider(
+			context.Background(),
+			token.AccessToken,
+			cfg.GoCloak.Realm,
+			"saml",
+		)
+		require.NoError(t, err)
+		require.Equal(t, "saml", *(provider.Alias))
+	})
+
+	t.Run("Get saml provider public broker config", func(t *testing.T) {
+		config, err := client.ExportIDPPublicBrokerConfig(
+			context.Background(),
+			token.AccessToken,
+			cfg.GoCloak.Realm,
+			"saml",
+		)
+		require.NoError(t, err)
+		require.NotEmpty(t, *(config))
+	})
+	t.Run("Delete saml provider", func(t *testing.T) {
+		err := client.DeleteIdentityProvider(
+			context.Background(),
+			token.AccessToken,
+			cfg.GoCloak.Realm,
+			"saml",
 		)
 		require.NoError(t, err)
 	})

--- a/gocloak.go
+++ b/gocloak.go
@@ -316,6 +316,8 @@ type GoCloak interface {
 	UpdateIdentityProvider(ctx context.Context, token, realm, alias string, providerRep IdentityProviderRepresentation) error
 	// DeleteIdentityProvider deletes the identity provider in a realm
 	DeleteIdentityProvider(ctx context.Context, token, realm, alias string) error
+	// ExportIDPPublicBrokerConfig exports the broker config for a given alias
+	ExportIDPPublicBrokerConfig(ctx context.Context, token, realm, alias string) (*string, error)
 
 	// *** Protection API ***
 	// GetResource returns a client's resource with the given id, using access token from client


### PR DESCRIPTION
This PR is adding support for Keycloak's API that allows the user to "Export public broker configuration for identity provider," which is documented here: https://www.keycloak.org/docs-api/5.0/rest-api/index.html#_identity_providers_resource

Before I began work on this feature, the many of the tests were not passing. This is what the test output looked like before I began development: 
[test_master_before_pr.txt](https://github.com/Nerzal/gocloak/files/6185792/test_master_before_pr.txt)

The only test that needed to be changed was TestGocloak_CreateProvider. This test was passing before the new client method was added. The test was updated to cover the new client method, and passes.  Additionally, I removed the Parallel flag, as the TestGocloak_CreateProvider is written with the expectation that each subtest is run sequentially. 
 
