### PR TITLE
fix: adding "DecisionStrategy" to "ResourceServerRepresentation" 

### DIFF
--- a/models.go
+++ b/models.go
@@ -445,6 +445,7 @@ type ResourceServerRepresentation struct {
 	PolicyEnforcementMode         *PolicyEnforcementMode    `json:"policyEnforcementMode,omitempty"`
 	Resources                     *[]ResourceRepresentation `json:"resources,omitempty"`
 	Scopes                        *[]ScopeRepresentation    `json:"scopes,omitempty"`
+	DecisionStrategy              *DecisionStrategy         `json:"decisionStrategy,omitempty"`
 }
 
 // RoleDefinition represents a role in a RolePolicyRepresentation


### PR DESCRIPTION
fix: adding "DecisionStrategy" to "ResourceServerRepresentation" in as per keycloak documentation `https://www.keycloak.org/docs-api/9.0/rest-api/index.html#_resourceserverrepresentation` to be able to dictate how permission are evaluated 

Thanks for your contribution!
Hi, if there is an issue, that your PR adresses, please link it! 
https://github.com/Nerzal/gocloak/issues/265


