### PR TITLE
Add ImportIdentityProviderConfig method

### DIFF
--- a/client.go
+++ b/client.go
@@ -2305,6 +2305,26 @@ func (client *gocloak) DeleteIdentityProvider(ctx context.Context, token, realm,
 	return checkForError(resp, err, errMessage)
 }
 
+// ImportIdentityProviderConfig parses and returns the identity provider config at a given URL
+func (client *gocloak) ImportIdentityProviderConfig(ctx context.Context, token, realm, fromURL, providerID string) (map[string]string, error) {
+	const errMessage = "could not import config"
+
+	result := make(map[string]string)
+	resp, err := client.getRequestWithBearerAuth(ctx, token).
+		SetResult(&result).
+		SetBody(map[string]string{
+			"fromUrl":    fromURL,
+			"providerId": providerID,
+		}).
+		Post(client.getAdminRealmURL(realm, "identity-provider", "import-config"))
+
+	if err := checkForError(resp, err, errMessage); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 // ------------------
 // Protection API
 // ------------------

--- a/gocloak.go
+++ b/gocloak.go
@@ -316,6 +316,8 @@ type GoCloak interface {
 	UpdateIdentityProvider(ctx context.Context, token, realm, alias string, providerRep IdentityProviderRepresentation) error
 	// DeleteIdentityProvider deletes the identity provider in a realm
 	DeleteIdentityProvider(ctx context.Context, token, realm, alias string) error
+	// ImportIdentityProviderConfig parses and returns the identity provider config at a given URL
+	ImportIdentityProviderConfig(ctx context.Context, token, realm, fromURL, providerID string) (map[string]string, error)
 
 	// *** Protection API ***
 	// GetResource returns a client's resource with the given id, using access token from client


### PR DESCRIPTION
Hi! 

First of all, thank you for offering and maintaining this great Keycloak client, it's highly appreciated. ❤️ 

Secondly, this PR adds support for the following API call:
<details>
<summary>Raw call</summary>

```
POST http://localhost:8080/auth/admin/realms/master/identity-provider/import-config

POST BODY
{
	"fromUrl": "https://accounts.google.com/.well-known/openid-configuration",
	"providerId": "oidc"
}

RESPONSE BODY
{
	"userInfoUrl": "https://openidconnect.googleapis.com/v1/userinfo",
	"validateSignature": "true",
	"tokenUrl": "https://oauth2.googleapis.com/token",
	"authorizationUrl": "https://accounts.google.com/o/oauth2/v2/auth",
	"jwksUrl": "https://www.googleapis.com/oauth2/v3/certs",
	"issuer": "https://accounts.google.com",
	"useJwksUrl": "true"
}
```

</details>

Tests pass locally for me, shown as follows.
<details>
<summary>Local test output</summary>

```
=== RUN   TestGocloak_ImportIdentityProviderConfig
=== PAUSE TestGocloak_ImportIdentityProviderConfig
=== CONT  TestGocloak_ImportIdentityProviderConfig
    client_test.go:489: [DEBUG] 
        ==============================================================================
        ~~~ REQUEST ~~~
        POST  /auth/realms/master/protocol/openid-connect/token  HTTP/1.1
        HOST   : localhost:8080
        HEADERS:
        	Content-Type: application/x-www-form-urlencoded
        	User-Agent: go-resty/2.3.0 (https://github.com/go-resty/resty)
        BODY   :
        client_id=admin-cli&grant_type=password&password=cyral&response_type=token&username=cyral
        ------------------------------------------------------------------------------
        ~~~ RESPONSE ~~~
        STATUS       : 200 OK
        PROTO        : HTTP/1.1
        RECEIVED AT  : 2021-03-25T09:31:12.575115-07:00
        TIME DURATION: 107.820451ms
        HEADERS      :
        	Cache-Control: no-store
        	Connection: keep-alive
        	Content-Length: 1717
        	Content-Type: application/json
        	Date: Thu, 25 Mar 2021 16:31:12 GMT
        	Pragma: no-cache
        	Referrer-Policy: no-referrer
        	Set-Cookie: KEYCLOAK_LOCALE=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0; Path=/auth/realms/master/; HttpOnly, KC_RESTART=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0; Path=/auth/realms/master/; HttpOnly
        	Strict-Transport-Security: max-age=31536000; includeSubDomains
        	X-Content-Type-Options: nosniff
        	X-Frame-Options: SAMEORIGIN
        	X-Xss-Protection: 1; mode=block
        BODY         :
        {
           "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJBNkRNWVJ6QWlZSHMteXpDWGdzMVdjU3BIZFptQk9DMlVEVTJ1bWY3QjlnIn0.eyJleHAiOjE2MTY2ODk5MzIsImlhdCI6MTYxNjY4OTg3MiwianRpIjoiMmQyNzA5ZjgtMDZlYy00NjBlLThiYjctMjRlMjU1Njc3ZDZlIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL2F1dGgvcmVhbG1zL21hc3RlciIsInN1YiI6ImYxNGUxMmQyLTUzMGUtNGM1NC04YzRkLTg4MGY2MzlkZWVkMCIsInR5cCI6IkJlYXJlciIsImF6cCI6ImFkbWluLWNsaSIsInNlc3Npb25fc3RhdGUiOiI3NTA1ZjkyNi1lMGJiLTQ2ZWMtOTg1My0zN2NmMzNmZDA2MWMiLCJhY3IiOiIxIiwic2NvcGUiOiJwcm9maWxlIGVtYWlsIiwiZW1haWxfdmVyaWZpZWQiOmZhbHNlLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJjeXJhbCJ9.XdLiRhXazMfVtpvlouND7mLL68FVYRCRVy3tLGgy93xnHSkEmhPHjG6dFcawUJEG9lxF9-HDgygSjS0sogzfeodyW0d9Nt1IzUX8t8B5M1RxW5uoTUWtaxSI-7B8xyudOy5iW7mxVneL6_7GPAlPrXgmpE_sVAwfkxc__2lrK_47LfwtNcbZY4FQnMlR73-uukVkpvXk7xE_bX2Bpc51tgkqmh2A7Dgo3CF6iHadoUoW4p1y4I-j0AIFHETuQ-uL4bT4kBKrtvJn6wWUzIW5befXLed7rY5ObApRkwybo9vzs3kHRf3POLpQDrOlcq4SudmJ8qsXMagkM30F-avgQQ",
           "expires_in": 60,
           "refresh_expires_in": 1800,
           "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0Y2YzYjIyYy1mYTk3LTQyZmYtOTYwMC1hMWUxZjQzNDY3YzMifQ.eyJleHAiOjE2MTY2OTE2NzIsImlhdCI6MTYxNjY4OTg3MiwianRpIjoiOWIxYmZiOWItZmE4ZS00MDc1LTk3OGYtYmU1ODEzZjY5NzA5IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL2F1dGgvcmVhbG1zL21hc3RlciIsImF1ZCI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9hdXRoL3JlYWxtcy9tYXN0ZXIiLCJzdWIiOiJmMTRlMTJkMi01MzBlLTRjNTQtOGM0ZC04ODBmNjM5ZGVlZDAiLCJ0eXAiOiJSZWZyZXNoIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6Ijc1MDVmOTI2LWUwYmItNDZlYy05ODUzLTM3Y2YzM2ZkMDYxYyIsInNjb3BlIjoicHJvZmlsZSBlbWFpbCJ9.j7u-MT5DpW02OYhSg9NnsHVukPK6-x8rs8j5I9Qlj34",
           "token_type": "bearer",
           "not-before-policy": 0,
           "session_state": "7505f926-e0bb-46ec-9853-37cf33fd061c",
           "scope": "profile email"
        }
        ==============================================================================

Debugger finished with exit code 0
```

</details>

You may notice that the test I added causes the test Keycloak instance to call a real URL of `https://accounts.google.com/.well-known/openid-configuration`, and if the contents of that URL were to change, the test would fail, causing the test to potentially be flaky in the future.

I added the test way because the rest of the file takes a similar approach, but I'm flexible. I alternatively could fire the test at an `httptest` mock server that returns a fixture. I'm open to other approaches as well, whatever you'd prefer, just let me know.

Thanks again!