### PR TITLE
Add CreateIdentityProviderMapper call

### DIFF
--- a/client.go
+++ b/client.go
@@ -2305,6 +2305,17 @@ func (client *gocloak) DeleteIdentityProvider(ctx context.Context, token, realm,
 	return checkForError(resp, err, errMessage)
 }
 
+// CreateIdentityProviderMapper creates an instance of an identity provider mapper associated with the given alias
+func (client *gocloak) CreateIdentityProviderMapper(ctx context.Context, token, realm, alias string, mapper IdentityProviderMapper) error {
+	const errMessage = "could not create mapper for identity provider"
+
+	resp, err := client.getRequestWithBearerAuth(ctx, token).
+		SetBody(mapper).
+		Post(client.getAdminRealmURL(realm, "identity-provider", "instances", alias, "mappers"))
+
+	return checkForError(resp, err, errMessage)
+}
+
 // ------------------
 // Protection API
 // ------------------

--- a/client_test.go
+++ b/client_test.go
@@ -3819,6 +3819,24 @@ func TestGocloak_CreateGetDeleteUserFederatedIdentity(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, idp, res)
 
+	err = client.CreateIdentityProviderMapper(
+		context.Background(),
+		token.AccessToken,
+		cfg.GoCloak.Realm,
+		"google",
+		gocloak.IdentityProviderMapper{
+			Name:                   gocloak.StringP("add-google-origin-attribute"),
+			IdentityProviderMapper: gocloak.StringP("hardcoded-attribute-idp-mapper"),
+			IdentityProviderAlias:  gocloak.StringP("google"),
+			Config: &map[string]string{
+				"syncMode":        "INHERIT",
+				"attribute":       "origin",
+				"attribute.value": "google",
+			},
+		},
+	)
+	require.NoError(t, err)
+
 	defer func() {
 		err = client.DeleteIdentityProvider(
 			context.Background(),

--- a/gocloak.go
+++ b/gocloak.go
@@ -316,6 +316,8 @@ type GoCloak interface {
 	UpdateIdentityProvider(ctx context.Context, token, realm, alias string, providerRep IdentityProviderRepresentation) error
 	// DeleteIdentityProvider deletes the identity provider in a realm
 	DeleteIdentityProvider(ctx context.Context, token, realm, alias string) error
+	// CreateIdentityProviderMapper creates an instance of an identity provider mapper associated with the given alias
+	CreateIdentityProviderMapper(ctx context.Context, token, realm, alias string, mapper IdentityProviderMapper) error
 
 	// *** Protection API ***
 	// GetResource returns a client's resource with the given id, using access token from client

--- a/models.go
+++ b/models.go
@@ -899,6 +899,13 @@ type IdentityProviderRepresentation struct {
 	TrustEmail                *bool              `json:"trustEmail,omitempty"`
 }
 
+type IdentityProviderMapper struct {
+	Name                   *string            `json:"name,omitempty"`
+	IdentityProviderMapper *string            `json:"identityProviderMapper,omitempty"`
+	IdentityProviderAlias  *string            `json:"identityProviderAlias,omitempty"`
+	Config                 *map[string]string `json:"config"`
+}
+
 // GetResourceParams represents the optional parameters for getting resources
 type GetResourceParams struct {
 	Deep        *bool   `json:"deep,string,omitempty"`

--- a/models.go
+++ b/models.go
@@ -899,6 +899,8 @@ type IdentityProviderRepresentation struct {
 	TrustEmail                *bool              `json:"trustEmail,omitempty"`
 }
 
+// IdentityProviderMapper represents the body of a call to add a mapper to
+// an identity provider
 type IdentityProviderMapper struct {
 	Name                   *string            `json:"name,omitempty"`
 	IdentityProviderMapper *string            `json:"identityProviderMapper,omitempty"`


### PR DESCRIPTION
Hello!

This PR adds support for adding mappers to identity providers. The added test passes locally, here's some sample output:

<details>
<summary>Test output</summary>

```
=== RUN   TestGocloak_CreateGetDeleteUserFederatedIdentity
    client_test.go:489: [DEBUG] 
        ==============================================================================
        ~~~ REQUEST ~~~
        POST  /auth/realms/master/protocol/openid-connect/token  HTTP/1.1
        HOST   : localhost:8080
        HEADERS:
        	Content-Type: application/x-www-form-urlencoded
        	User-Agent: go-resty/2.3.0 (https://github.com/go-resty/resty)
        BODY   :
        client_id=admin-cli&grant_type=password&password=cyral&response_type=token&username=cyral
        ------------------------------------------------------------------------------
        ~~~ RESPONSE ~~~
        STATUS       : 200 OK
        PROTO        : HTTP/1.1
        RECEIVED AT  : 2021-03-26T15:53:01.610222-07:00
        TIME DURATION: 100.589512ms
        HEADERS      :
        	Cache-Control: no-store
        	Connection: keep-alive
        	Content-Length: 1717
        	Content-Type: application/json
        	Date: Fri, 26 Mar 2021 22:53:01 GMT
        	Pragma: no-cache
        	Referrer-Policy: no-referrer
        	Set-Cookie: KEYCLOAK_LOCALE=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0; Path=/auth/realms/master/; HttpOnly, KC_RESTART=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0; Path=/auth/realms/master/; HttpOnly
        	Strict-Transport-Security: max-age=31536000; includeSubDomains
        	X-Content-Type-Options: nosniff
        	X-Frame-Options: SAMEORIGIN
        	X-Xss-Protection: 1; mode=block
        BODY         :
        {
           "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJmWk1YZmxTR1dKZnZnYV84M2xrSDdtOFZGSm0wNHRlVmEzTWZpNDVTU1c4In0.eyJleHAiOjE2MTY3OTkyNDEsImlhdCI6MTYxNjc5OTE4MSwianRpIjoiYjZjZjA3ZjQtODE2My00OTZhLTgyOTUtMWY3NjYzNDlkYWM5IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL2F1dGgvcmVhbG1zL21hc3RlciIsInN1YiI6IjFhY2E1MTA2LTc5ZmEtNDgxYi1hNmZmLTQ0ODkzY2IwNThlMyIsInR5cCI6IkJlYXJlciIsImF6cCI6ImFkbWluLWNsaSIsInNlc3Npb25fc3RhdGUiOiJjNmVjNTY1NC0yNWEzLTRkNjItODBiMC01N2RhOWMxOTMyMzkiLCJhY3IiOiIxIiwic2NvcGUiOiJlbWFpbCBwcm9maWxlIiwiZW1haWxfdmVyaWZpZWQiOmZhbHNlLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJjeXJhbCJ9.IeI0D5w6uSnDU6w-aa_xkiPNRq-M2684M321hKrVtEoz1HJzXV5-Z3cWZrRYTeIU_Iy8Nwj3zhGjS7TN78YEIO8aBtziM0hVs8aretz2Q2UMOgk3YjUYYnJHB4cefbIp8NP0_54IXC7OXhrYMn0kltGpg1qStO08OCN-1DbtjwoPtf_IqcbcOFCfPxWCvGI8ex576Vl65pbPqKmUNM-1P_fxkxYvyuR91S-lrUzp2hXH71y4UM-WnIXm9kdmGsgzhPBDZffle9ziPQO006-RKdjQGrnB_bRwWHK6V3Cxjgd-NqQ4C-tJ5jWMdv-4OfnenMrcxLG_VU8pkRcjwIDLrw",
           "expires_in": 60,
           "refresh_expires_in": 1800,
           "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0ZjZhNTNjYi0yMmY0LTRjYWYtYTg1Yy1lNjViZTg2NTRhYmMifQ.eyJleHAiOjE2MTY4MDA5ODEsImlhdCI6MTYxNjc5OTE4MSwianRpIjoiYjAxMTM1MjQtMWU0MS00YzkwLTg5MzktMTU0YzE4ZTU4OTEzIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL2F1dGgvcmVhbG1zL21hc3RlciIsImF1ZCI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9hdXRoL3JlYWxtcy9tYXN0ZXIiLCJzdWIiOiIxYWNhNTEwNi03OWZhLTQ4MWItYTZmZi00NDg5M2NiMDU4ZTMiLCJ0eXAiOiJSZWZyZXNoIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6ImM2ZWM1NjU0LTI1YTMtNGQ2Mi04MGIwLTU3ZGE5YzE5MzIzOSIsInNjb3BlIjoiZW1haWwgcHJvZmlsZSJ9.Ot4Y_2MQL_1jW9t_Gei-161nfeYtzFEA4pjumMdIMXc",
           "token_type": "bearer",
           "not-before-policy": 0,
           "session_state": "c6ec5654-25a3-4d62-80b0-57da9c193239",
           "scope": "email profile"
        }
        ==============================================================================
    client_test.go:489: [DEBUG] 
        ==============================================================================
        ~~~ REQUEST ~~~
        POST  /auth/realms/master/protocol/openid-connect/token  HTTP/1.1
        HOST   : localhost:8080
        HEADERS:
        	Content-Type: application/x-www-form-urlencoded
        	User-Agent: go-resty/2.3.0 (https://github.com/go-resty/resty)
        BODY   :
        client_id=admin-cli&grant_type=password&password=cyral&response_type=token&username=cyral
        ------------------------------------------------------------------------------
        ~~~ RESPONSE ~~~
        STATUS       : 200 OK
        PROTO        : HTTP/1.1
        RECEIVED AT  : 2021-03-26T15:53:01.709963-07:00
        TIME DURATION: 99.460202ms
        HEADERS      :
        	Cache-Control: no-store
        	Connection: keep-alive
        	Content-Length: 1717
        	Content-Type: application/json
        	Date: Fri, 26 Mar 2021 22:53:01 GMT
        	Pragma: no-cache
        	Referrer-Policy: no-referrer
        	Set-Cookie: KEYCLOAK_LOCALE=; Version=1; Comment=Expiring cookie; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0; Path=/auth/realms/master/; HttpOnly, KC_RESTART=; Version=1; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Max-Age=0; Path=/auth/realms/master/; HttpOnly
        	Strict-Transport-Security: max-age=31536000; includeSubDomains
        	X-Content-Type-Options: nosniff
        	X-Frame-Options: SAMEORIGIN
        	X-Xss-Protection: 1; mode=block
        BODY         :
        {
           "access_token": "eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJmWk1YZmxTR1dKZnZnYV84M2xrSDdtOFZGSm0wNHRlVmEzTWZpNDVTU1c4In0.eyJleHAiOjE2MTY3OTkyNDEsImlhdCI6MTYxNjc5OTE4MSwianRpIjoiZGEzMzVhYzUtZDM2Ni00MWE2LWFkMzgtZmMwYjIwZTVkNDExIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL2F1dGgvcmVhbG1zL21hc3RlciIsInN1YiI6IjFhY2E1MTA2LTc5ZmEtNDgxYi1hNmZmLTQ0ODkzY2IwNThlMyIsInR5cCI6IkJlYXJlciIsImF6cCI6ImFkbWluLWNsaSIsInNlc3Npb25fc3RhdGUiOiI1OWRhNjY4MC05ZTU0LTRjN2QtYWM2Zi0xODk5YjQxNmRhN2MiLCJhY3IiOiIxIiwic2NvcGUiOiJlbWFpbCBwcm9maWxlIiwiZW1haWxfdmVyaWZpZWQiOmZhbHNlLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJjeXJhbCJ9.dQMPJkxPqiW2_YiSrxr1RtqIWD-_Xf2iVuZJx3IJtUYpqrCt2Jv1Gl4nxOiLKHNMuXi7bkgnkI02utd-V07Zn5RK1HtHLpgCL9v2yWmblm18Bbv4Hbf3heJA08fsDntXBL90l8kb0rlNSaMpyYk1CUA8whX28YTUb6_UVrb4ubTj5F05TV2eaZwsdhk-nTg17c-4w14N54ula9GUD_Pm-9W8aMiIUppALEPLyFrq2F-NQ2s4LRV5IT18IPPSfTg6I2kO9jgzbx3-mAAvvBLz9y-VNK4gNNfoyIGziNI7J8ciC88A-Y8uMDE3aY70D5gWjSwzS3rEEC_cU4c4fTnn3g",
           "expires_in": 60,
           "refresh_expires_in": 1800,
           "refresh_token": "eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI0ZjZhNTNjYi0yMmY0LTRjYWYtYTg1Yy1lNjViZTg2NTRhYmMifQ.eyJleHAiOjE2MTY4MDA5ODEsImlhdCI6MTYxNjc5OTE4MSwianRpIjoiOWZhMDZlMGQtNjI5NC00NjA2LWJkOTctMDYyZDIxOTk5MDAwIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL2F1dGgvcmVhbG1zL21hc3RlciIsImF1ZCI6Imh0dHA6Ly9sb2NhbGhvc3Q6ODA4MC9hdXRoL3JlYWxtcy9tYXN0ZXIiLCJzdWIiOiIxYWNhNTEwNi03OWZhLTQ4MWItYTZmZi00NDg5M2NiMDU4ZTMiLCJ0eXAiOiJSZWZyZXNoIiwiYXpwIjoiYWRtaW4tY2xpIiwic2Vzc2lvbl9zdGF0ZSI6IjU5ZGE2NjgwLTllNTQtNGM3ZC1hYzZmLTE4OTliNDE2ZGE3YyIsInNjb3BlIjoiZW1haWwgcHJvZmlsZSJ9.n8iPJIam2NmqsRG_ktYURDYwmFm-ZaPR1d2V7tetuHs",
           "token_type": "bearer",
           "not-before-policy": 0,
           "session_state": "59da6680-9e54-4c7d-ac6f-1899b416da7c",
           "scope": "email profile"
        }
        ==============================================================================
    client_test.go:489: [DEBUG] 
        ==============================================================================
        ~~~ REQUEST ~~~
        POST  /auth/admin/realms/gocloak/users  HTTP/1.1
        HOST   : localhost:8080
        HEADERS:
        	Accept: application/json
        	Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJmWk1YZmxTR1dKZnZnYV84M2xrSDdtOFZGSm0wNHRlVmEzTWZpNDVTU1c4In0.eyJleHAiOjE2MTY3OTkyNDEsImlhdCI6MTYxNjc5OTE4MSwianRpIjoiZGEzMzVhYzUtZDM2Ni00MWE2LWFkMzgtZmMwYjIwZTVkNDExIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL2F1dGgvcmVhbG1zL21hc3RlciIsInN1YiI6IjFhY2E1MTA2LTc5ZmEtNDgxYi1hNmZmLTQ0ODkzY2IwNThlMyIsInR5cCI6IkJlYXJlciIsImF6cCI6ImFkbWluLWNsaSIsInNlc3Npb25fc3RhdGUiOiI1OWRhNjY4MC05ZTU0LTRjN2QtYWM2Zi0xODk5YjQxNmRhN2MiLCJhY3IiOiIxIiwic2NvcGUiOiJlbWFpbCBwcm9maWxlIiwiZW1haWxfdmVyaWZpZWQiOmZhbHNlLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJjeXJhbCJ9.dQMPJkxPqiW2_YiSrxr1RtqIWD-_Xf2iVuZJx3IJtUYpqrCt2Jv1Gl4nxOiLKHNMuXi7bkgnkI02utd-V07Zn5RK1HtHLpgCL9v2yWmblm18Bbv4Hbf3heJA08fsDntXBL90l8kb0rlNSaMpyYk1CUA8whX28YTUb6_UVrb4ubTj5F05TV2eaZwsdhk-nTg17c-4w14N54ula9GUD_Pm-9W8aMiIUppALEPLyFrq2F-NQ2s4LRV5IT18IPPSfTg6I2kO9jgzbx3-mAAvvBLz9y-VNK4gNNfoyIGziNI7J8ciC88A-Y8uMDE3aY70D5gWjSwzS3rEEC_cU4c4fTnn3g
        	Content-Type: application/json
        	User-Agent: go-resty/2.3.0 (https://github.com/go-resty/resty)
        BODY   :
        {
           "username": "email20740@localhost",
           "enabled": true,
           "firstName": "FirstName66528",
           "lastName": "LastName50460",
           "email": "email20740@localhost",
           "attributes": {
              "bar": [
                 "baz"
              ],
              "foo": [
                 "bar",
                 "alice",
                 "bob",
                 "roflcopter"
              ]
           }
        }
        ------------------------------------------------------------------------------
        ~~~ RESPONSE ~~~
        STATUS       : 201 Created
        PROTO        : HTTP/1.1
        RECEIVED AT  : 2021-03-26T15:53:01.725396-07:00
        TIME DURATION: 14.982986ms
        HEADERS      :
        	Connection: keep-alive
        	Content-Length: 0
        	Date: Fri, 26 Mar 2021 22:53:01 GMT
        	Location: http://localhost:8080/auth/admin/realms/gocloak/users/8afd2815-0437-400e-bd2a-bc5f8d56e04c
        	Referrer-Policy: no-referrer
        	Strict-Transport-Security: max-age=31536000; includeSubDomains
        	X-Content-Type-Options: nosniff
        	X-Frame-Options: SAMEORIGIN
        	X-Xss-Protection: 1; mode=block
        BODY         :
        
        ==============================================================================
    client_test.go:2499: Created User: {ID:0xc00006c360 CreatedTimestamp:<nil> Username:0xc00006c340 Enabled:0xc00002c2f0 Totp:<nil> EmailVerified:<nil> FirstName:0xc00006c320 LastName:0xc00006c330 Email:0xc00006c340 FederationLink:<nil> Attributes:0xc000010020 DisableableCredentialTypes:<nil> RequiredActions:<nil> Access:<nil> ClientRoles:<nil> RealmRoles:<nil> Groups:<nil> ServiceAccountClientID:<nil> Credentials:<nil>}
    client_test.go:489: [DEBUG] 
        ==============================================================================
        ~~~ REQUEST ~~~
        POST  /auth/admin/realms/gocloak/identity-provider/instances  HTTP/1.1
        HOST   : localhost:8080
        HEADERS:
        	Accept: application/json
        	Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJmWk1YZmxTR1dKZnZnYV84M2xrSDdtOFZGSm0wNHRlVmEzTWZpNDVTU1c4In0.eyJleHAiOjE2MTY3OTkyNDEsImlhdCI6MTYxNjc5OTE4MSwianRpIjoiYjZjZjA3ZjQtODE2My00OTZhLTgyOTUtMWY3NjYzNDlkYWM5IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL2F1dGgvcmVhbG1zL21hc3RlciIsInN1YiI6IjFhY2E1MTA2LTc5ZmEtNDgxYi1hNmZmLTQ0ODkzY2IwNThlMyIsInR5cCI6IkJlYXJlciIsImF6cCI6ImFkbWluLWNsaSIsInNlc3Npb25fc3RhdGUiOiJjNmVjNTY1NC0yNWEzLTRkNjItODBiMC01N2RhOWMxOTMyMzkiLCJhY3IiOiIxIiwic2NvcGUiOiJlbWFpbCBwcm9maWxlIiwiZW1haWxfdmVyaWZpZWQiOmZhbHNlLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJjeXJhbCJ9.IeI0D5w6uSnDU6w-aa_xkiPNRq-M2684M321hKrVtEoz1HJzXV5-Z3cWZrRYTeIU_Iy8Nwj3zhGjS7TN78YEIO8aBtziM0hVs8aretz2Q2UMOgk3YjUYYnJHB4cefbIp8NP0_54IXC7OXhrYMn0kltGpg1qStO08OCN-1DbtjwoPtf_IqcbcOFCfPxWCvGI8ex576Vl65pbPqKmUNM-1P_fxkxYvyuR91S-lrUzp2hXH71y4UM-WnIXm9kdmGsgzhPBDZffle9ziPQO006-RKdjQGrnB_bRwWHK6V3Cxjgd-NqQ4C-tJ5jWMdv-4OfnenMrcxLG_VU8pkRcjwIDLrw
        	Content-Type: application/json
        	User-Agent: go-resty/2.3.0 (https://github.com/go-resty/resty)
        BODY   :
        {
           "alias": "google",
           "config": {
              "clientId": "realm-management",
              "clientSecret": "bc8b0dd8-d311-4473-8c52-c509115567ba",
              "hostedDomain": "test.io"
           },
           "displayName": "Google",
           "enabled": true,
           "firstBrokerLoginFlowAlias": "first broker login",
           "providerId": "google",
           "trustEmail": true
        }
        ------------------------------------------------------------------------------
        ~~~ RESPONSE ~~~
        STATUS       : 201 Created
        PROTO        : HTTP/1.1
        RECEIVED AT  : 2021-03-26T15:53:01.740941-07:00
        TIME DURATION: 15.346659ms
        HEADERS      :
        	Connection: keep-alive
        	Content-Length: 0
        	Date: Fri, 26 Mar 2021 22:53:01 GMT
        	Location: http://localhost:8080/auth/admin/realms/gocloak/identity-provider/instances/google
        	Referrer-Policy: no-referrer
        	Strict-Transport-Security: max-age=31536000; includeSubDomains
        	X-Content-Type-Options: nosniff
        	X-Frame-Options: SAMEORIGIN
        	X-Xss-Protection: 1; mode=block
        BODY         :
        
        ==============================================================================
    client_test.go:489: [DEBUG] 
        ==============================================================================
        ~~~ REQUEST ~~~
        POST  /auth/admin/realms/gocloak/identity-provider/instances/google/mappers  HTTP/1.1
        HOST   : localhost:8080
        HEADERS:
        	Accept: application/json
        	Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJmWk1YZmxTR1dKZnZnYV84M2xrSDdtOFZGSm0wNHRlVmEzTWZpNDVTU1c4In0.eyJleHAiOjE2MTY3OTkyNDEsImlhdCI6MTYxNjc5OTE4MSwianRpIjoiYjZjZjA3ZjQtODE2My00OTZhLTgyOTUtMWY3NjYzNDlkYWM5IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL2F1dGgvcmVhbG1zL21hc3RlciIsInN1YiI6IjFhY2E1MTA2LTc5ZmEtNDgxYi1hNmZmLTQ0ODkzY2IwNThlMyIsInR5cCI6IkJlYXJlciIsImF6cCI6ImFkbWluLWNsaSIsInNlc3Npb25fc3RhdGUiOiJjNmVjNTY1NC0yNWEzLTRkNjItODBiMC01N2RhOWMxOTMyMzkiLCJhY3IiOiIxIiwic2NvcGUiOiJlbWFpbCBwcm9maWxlIiwiZW1haWxfdmVyaWZpZWQiOmZhbHNlLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJjeXJhbCJ9.IeI0D5w6uSnDU6w-aa_xkiPNRq-M2684M321hKrVtEoz1HJzXV5-Z3cWZrRYTeIU_Iy8Nwj3zhGjS7TN78YEIO8aBtziM0hVs8aretz2Q2UMOgk3YjUYYnJHB4cefbIp8NP0_54IXC7OXhrYMn0kltGpg1qStO08OCN-1DbtjwoPtf_IqcbcOFCfPxWCvGI8ex576Vl65pbPqKmUNM-1P_fxkxYvyuR91S-lrUzp2hXH71y4UM-WnIXm9kdmGsgzhPBDZffle9ziPQO006-RKdjQGrnB_bRwWHK6V3Cxjgd-NqQ4C-tJ5jWMdv-4OfnenMrcxLG_VU8pkRcjwIDLrw
        	Content-Type: application/json
        	User-Agent: go-resty/2.3.0 (https://github.com/go-resty/resty)
        BODY   :
        {
           "name": "add-google-origin-attribute",
           "identityProviderMapper": "hardcoded-attribute-idp-mapper",
           "identityProviderAlias": "google",
           "config": {
              "attribute": "origin",
              "attribute.value": "google",
              "syncMode": "INHERIT"
           }
        }
        ------------------------------------------------------------------------------
        ~~~ RESPONSE ~~~
        STATUS       : 201 Created
        PROTO        : HTTP/1.1
        RECEIVED AT  : 2021-03-26T15:53:01.766596-07:00
        TIME DURATION: 25.475792ms
        HEADERS      :
        	Connection: keep-alive
        	Content-Length: 0
        	Date: Fri, 26 Mar 2021 22:53:01 GMT
        	Location: http://localhost:8080/auth/admin/realms/gocloak/identity-provider/instances/google/mappers/587c6519-7159-4a00-a941-fbff04c4ddd3
        	Referrer-Policy: no-referrer
        	Strict-Transport-Security: max-age=31536000; includeSubDomains
        	X-Content-Type-Options: nosniff
        	X-Frame-Options: SAMEORIGIN
        	X-Xss-Protection: 1; mode=block
        BODY         :
        
        ==============================================================================
    client_test.go:489: [DEBUG] 
        ==============================================================================
        ~~~ REQUEST ~~~
        POST  /auth/admin/realms/gocloak/users/8afd2815-0437-400e-bd2a-bc5f8d56e04c/federated-identity/google  HTTP/1.1
        HOST   : localhost:8080
        HEADERS:
        	Accept: application/json
        	Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJmWk1YZmxTR1dKZnZnYV84M2xrSDdtOFZGSm0wNHRlVmEzTWZpNDVTU1c4In0.eyJleHAiOjE2MTY3OTkyNDEsImlhdCI6MTYxNjc5OTE4MSwianRpIjoiYjZjZjA3ZjQtODE2My00OTZhLTgyOTUtMWY3NjYzNDlkYWM5IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL2F1dGgvcmVhbG1zL21hc3RlciIsInN1YiI6IjFhY2E1MTA2LTc5ZmEtNDgxYi1hNmZmLTQ0ODkzY2IwNThlMyIsInR5cCI6IkJlYXJlciIsImF6cCI6ImFkbWluLWNsaSIsInNlc3Npb25fc3RhdGUiOiJjNmVjNTY1NC0yNWEzLTRkNjItODBiMC01N2RhOWMxOTMyMzkiLCJhY3IiOiIxIiwic2NvcGUiOiJlbWFpbCBwcm9maWxlIiwiZW1haWxfdmVyaWZpZWQiOmZhbHNlLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJjeXJhbCJ9.IeI0D5w6uSnDU6w-aa_xkiPNRq-M2684M321hKrVtEoz1HJzXV5-Z3cWZrRYTeIU_Iy8Nwj3zhGjS7TN78YEIO8aBtziM0hVs8aretz2Q2UMOgk3YjUYYnJHB4cefbIp8NP0_54IXC7OXhrYMn0kltGpg1qStO08OCN-1DbtjwoPtf_IqcbcOFCfPxWCvGI8ex576Vl65pbPqKmUNM-1P_fxkxYvyuR91S-lrUzp2hXH71y4UM-WnIXm9kdmGsgzhPBDZffle9ziPQO006-RKdjQGrnB_bRwWHK6V3Cxjgd-NqQ4C-tJ5jWMdv-4OfnenMrcxLG_VU8pkRcjwIDLrw
        	Content-Type: application/json
        	User-Agent: go-resty/2.3.0 (https://github.com/go-resty/resty)
        BODY   :
        {
           "identityProvider": "google",
           "userId": "my-external-userid",
           "userName": "my-external-username"
        }
        ------------------------------------------------------------------------------
        ~~~ RESPONSE ~~~
        STATUS       : 204 No Content
        PROTO        : HTTP/1.1
        RECEIVED AT  : 2021-03-26T15:53:01.800107-07:00
        TIME DURATION: 33.351309ms
        HEADERS      :
        	Date: Fri, 26 Mar 2021 22:53:01 GMT
        	Referrer-Policy: no-referrer
        	Strict-Transport-Security: max-age=31536000; includeSubDomains
        	X-Content-Type-Options: nosniff
        	X-Frame-Options: SAMEORIGIN
        	X-Xss-Protection: 1; mode=block
        BODY         :
        
        ==============================================================================
    client_test.go:489: [DEBUG] 
        ==============================================================================
        ~~~ REQUEST ~~~
        GET  /auth/admin/realms/gocloak/users/8afd2815-0437-400e-bd2a-bc5f8d56e04c/federated-identity  HTTP/1.1
        HOST   : localhost:8080
        HEADERS:
        	Accept: application/json
        	Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJmWk1YZmxTR1dKZnZnYV84M2xrSDdtOFZGSm0wNHRlVmEzTWZpNDVTU1c4In0.eyJleHAiOjE2MTY3OTkyNDEsImlhdCI6MTYxNjc5OTE4MSwianRpIjoiYjZjZjA3ZjQtODE2My00OTZhLTgyOTUtMWY3NjYzNDlkYWM5IiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL2F1dGgvcmVhbG1zL21hc3RlciIsInN1YiI6IjFhY2E1MTA2LTc5ZmEtNDgxYi1hNmZmLTQ0ODkzY2IwNThlMyIsInR5cCI6IkJlYXJlciIsImF6cCI6ImFkbWluLWNsaSIsInNlc3Npb25fc3RhdGUiOiJjNmVjNTY1NC0yNWEzLTRkNjItODBiMC01N2RhOWMxOTMyMzkiLCJhY3IiOiIxIiwic2NvcGUiOiJlbWFpbCBwcm9maWxlIiwiZW1haWxfdmVyaWZpZWQiOmZhbHNlLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJjeXJhbCJ9.IeI0D5w6uSnDU6w-aa_xkiPNRq-M2684M321hKrVtEoz1HJzXV5-Z3cWZrRYTeIU_Iy8Nwj3zhGjS7TN78YEIO8aBtziM0hVs8aretz2Q2UMOgk3YjUYYnJHB4cefbIp8NP0_54IXC7OXhrYMn0kltGpg1qStO08OCN-1DbtjwoPtf_IqcbcOFCfPxWCvGI8ex576Vl65pbPqKmUNM-1P_fxkxYvyuR91S-lrUzp2hXH71y4UM-WnIXm9kdmGsgzhPBDZffle9ziPQO006-RKdjQGrnB_bRwWHK6V3Cxjgd-NqQ4C-tJ5jWMdv-4OfnenMrcxLG_VU8pkRcjwIDLrw
        	Content-Type: application/json
        	User-Agent: go-resty/2.3.0 (https://github.com/go-resty/resty)
        BODY   :
        ***** NO CONTENT *****
        ------------------------------------------------------------------------------
        ~~~ RESPONSE ~~~
        STATUS       : 200 OK
        PROTO        : HTTP/1.1
        RECEIVED AT  : 2021-03-26T15:53:01.808421-07:00
        TIME DURATION: 8.205298ms
        HEADERS      :
        	Cache-Control: no-cache
        	Connection: keep-alive
        	Content-Length: 95
        	Content-Type: application/json
        	Date: Fri, 26 Mar 2021 22:53:01 GMT
        	Referrer-Policy: no-referrer
        	Strict-Transport-Security: max-age=31536000; includeSubDomains
        	X-Content-Type-Options: nosniff
        	X-Frame-Options: SAMEORIGIN
        	X-Xss-Protection: 1; mode=block
        BODY         :
        [
           {
              "identityProvider": "google",
              "userId": "my-external-userid",
              "userName": "my-external-username"
           }
        ]
        ==============================================================================
    client_test.go:489: [DEBUG] 
        ==============================================================================
        ~~~ REQUEST ~~~
        DELETE  /auth/admin/realms/gocloak/users/8afd2815-0437-400e-bd2a-bc5f8d56e04c  HTTP/1.1
        HOST   : localhost:8080
        HEADERS:
        	Accept: application/json
        	Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJmWk1YZmxTR1dKZnZnYV84M2xrSDdtOFZGSm0wNHRlVmEzTWZpNDVTU1c4In0.eyJleHAiOjE2MTY3OTkyNDEsImlhdCI6MTYxNjc5OTE4MSwianRpIjoiZGEzMzVhYzUtZDM2Ni00MWE2LWFkMzgtZmMwYjIwZTVkNDExIiwiaXNzIjoiaHR0cDovL2xvY2FsaG9zdDo4MDgwL2F1dGgvcmVhbG1zL21hc3RlciIsInN1YiI6IjFhY2E1MTA2LTc5ZmEtNDgxYi1hNmZmLTQ0ODkzY2IwNThlMyIsInR5cCI6IkJlYXJlciIsImF6cCI6ImFkbWluLWNsaSIsInNlc3Npb25fc3RhdGUiOiI1OWRhNjY4MC05ZTU0LTRjN2QtYWM2Zi0xODk5YjQxNmRhN2MiLCJhY3IiOiIxIiwic2NvcGUiOiJlbWFpbCBwcm9maWxlIiwiZW1haWxfdmVyaWZpZWQiOmZhbHNlLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJjeXJhbCJ9.dQMPJkxPqiW2_YiSrxr1RtqIWD-_Xf2iVuZJx3IJtUYpqrCt2Jv1Gl4nxOiLKHNMuXi7bkgnkI02utd-V07Zn5RK1HtHLpgCL9v2yWmblm18Bbv4Hbf3heJA08fsDntXBL90l8kb0rlNSaMpyYk1CUA8whX28YTUb6_UVrb4ubTj5F05TV2eaZwsdhk-nTg17c-4w14N54ula9GUD_Pm-9W8aMiIUppALEPLyFrq2F-NQ2s4LRV5IT18IPPSfTg6I2kO9jgzbx3-mAAvvBLz9y-VNK4gNNfoyIGziNI7J8ciC88A-Y8uMDE3aY70D5gWjSwzS3rEEC_cU4c4fTnn3g
        	Content-Type: application/json
        	User-Agent: go-resty/2.3.0 (https://github.com/go-resty/resty)
        BODY   :
        ***** NO CONTENT *****
        ------------------------------------------------------------------------------
        ~~~ RESPONSE ~~~
        STATUS       : 204 No Content
        PROTO        : HTTP/1.1
        RECEIVED AT  : 2021-03-26T15:53:01.846528-07:00
        TIME DURATION: 37.883473ms
        HEADERS      :
        	Date: Fri, 26 Mar 2021 22:53:01 GMT
        	Referrer-Policy: no-referrer
        	Strict-Transport-Security: max-age=31536000; includeSubDomains
        	X-Content-Type-Options: nosniff
        	X-Frame-Options: SAMEORIGIN
        	X-Xss-Protection: 1; mode=block
        BODY         :
        
        ==============================================================================
--- PASS: TestGocloak_CreateGetDeleteUserFederatedIdentity (0.34s)
PASS

Process finished with exit code 0
```
</details>

Let me know if you'd like to see anything else. A big thank-you to the maintainers.