### PR TITLE
Support parsing identity provider config docs

### DIFF
--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -2352,6 +2353,26 @@ func (client *gocloak) ImportIdentityProviderConfig(ctx context.Context, token, 
 		SetResult(&result).
 		SetBody(map[string]string{
 			"fromUrl":    fromURL,
+			"providerId": providerID,
+		}).
+		Post(client.getAdminRealmURL(realm, "identity-provider", "import-config"))
+
+	if err := checkForError(resp, err, errMessage); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// ImportIdentityProviderConfigFromFile parses and returns the identity provider config from a given file
+func (client *gocloak) ImportIdentityProviderConfigFromFile(ctx context.Context, token, realm, providerID, fileName string, fileBody io.Reader) (map[string]string, error) {
+	const errMessage = "could not import config"
+
+	result := make(map[string]string)
+	resp, err := client.getRequestWithBearerAuth(ctx, token).
+		SetResult(&result).
+		SetFileReader("file", fileName, fileBody).
+		SetFormData(map[string]string{
 			"providerId": providerID,
 		}).
 		Post(client.getAdminRealmURL(realm, "identity-provider", "import-config"))

--- a/gocloak.go
+++ b/gocloak.go
@@ -2,6 +2,7 @@ package gocloak
 
 import (
 	"context"
+	"io"
 
 	"github.com/dgrijalva/jwt-go/v4"
 	"github.com/go-resty/resty/v2"
@@ -320,6 +321,8 @@ type GoCloak interface {
 	DeleteIdentityProvider(ctx context.Context, token, realm, alias string) error
 	// ImportIdentityProviderConfig parses and returns the identity provider config at a given URL
 	ImportIdentityProviderConfig(ctx context.Context, token, realm, fromURL, providerID string) (map[string]string, error)
+	// ImportIdentityProviderConfigFromFile parses and returns the identity provider config from a given file
+	ImportIdentityProviderConfigFromFile(ctx context.Context, token, realm, providerID, fileName string, fileBody io.Reader) (map[string]string, error)
 	// ExportIDPPublicBrokerConfig exports the broker config for a given alias
 	ExportIDPPublicBrokerConfig(ctx context.Context, token, realm, alias string) (*string, error)
 	// CreateIdentityProviderMapper creates an instance of an identity provider mapper associated with the given alias


### PR DESCRIPTION
This PR adds support for importing identity provider config documents. This is more specifically useful for parsing SAML metadata documents. 

The file body is taken as an `io.Reader` so the caller can stream it in if they want. If they have the whole thing in memory, though, they can just convert it to a `bytes.Reader` and it'll still work just fine.