### PR TITLE
bugfix: clear up `id of client` and `client_id` confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ go get github.com/Nerzal/gocloak/v8
  if err != nil {
   panic("Something wrong with the credentials or url")
  }
- 
+
  user := gocloak.User{
   FirstName: gocloak.StringP(""Bob"),
   LastName:  gocloak.StringP(""Uncle"),
@@ -113,12 +113,12 @@ go get github.com/Nerzal/gocloak/v8
 ```go
  client := gocloak.NewClient(hostname)
  ctx := context.Background()
- token, err := client.LoginClient(ctx, clientid, clientSecret, realm)
+ token, err := client.LoginClient(ctx, clientID, clientSecret, realm)
  if err != nil {
   panic("Login failed:"+ err.Error())
  }
 
- rptResult, err := client.RetrospectToken(ctx, token.AccessToken, clientid, clientSecret, realm)
+ rptResult, err := client.RetrospectToken(ctx, token.AccessToken, clientID, clientSecret, realm)
  if err != nil {
   panic("Inspection failed:"+ err.Error())
  }
@@ -170,7 +170,7 @@ type GoCloak interface {
  GetRequestingPartyToken(ctx context.Context, token, realm string, options RequestingPartyTokenOptions) (*JWT, error)
  GetRequestingPartyPermissions(ctx context.Context, token, realm string, options RequestingPartyTokenOptions) (*[]RequestingPartyPermission, error)
  GetRequestingPartyPermissionDecision(ctx context.Context, token, realm string, options RequestingPartyTokenOptions) (*RequestingPartyPermissionDecision, error)
- 
+
  Login(ctx context.Context, clientID, clientSecret, realm, username, password string) (*JWT, error)
  LoginOtp(ctx context.Context, clientID, clientSecret, realm, username, password, totp string) (*JWT, error)
  Logout(ctx context.Context, clientID, clientSecret, realm, refreshToken string) error
@@ -195,48 +195,48 @@ type GoCloak interface {
  CreateUser(ctx context.Context, token, realm string, user User) (string, error)
  CreateGroup(ctx context.Context, accessToken, realm string, group Group) (string, error)
  CreateChildGroup(ctx context.Context, token, realm, groupID string, group Group) (string, error)
- CreateClientRole(ctx context.Context, accessToken, realm, clientID string, role Role) (string, error)
- CreateClient(ctx context.Context, accessToken, realm string, clientID Client) (string, error)
+ CreateClientRole(ctx context.Context, accessToken, realm, idOfClient string, role Role) (string, error)
+ CreateClient(ctx context.Context, accessToken, realm string, newClient Client) (string, error)
  CreateClientScope(ctx context.Context, accessToken, realm string, scope ClientScope) (string, error)
  CreateComponent(ctx context.Context, accessToken, realm string, component Component) (string, error)
- CreateClientScopeMappingsRealmRoles(ctx context.Context, token, realm, clientID string, roles []Role) error
- CreateClientScopeMappingsClientRoles(ctx context.Context, token, realm, clientID, clientsID string, roles []Role) error
+ CreateClientScopeMappingsRealmRoles(ctx context.Context, token, realm, idOfClient string, roles []Role) error
+ CreateClientScopeMappingsClientRoles(ctx context.Context, token, realm, idOfClient, idOfSelectedClient string, roles []Role) error
 
  UpdateUser(ctx context.Context, accessToken, realm string, user User) error
  UpdateGroup(ctx context.Context, accessToken, realm string, updatedGroup Group) error
- UpdateRole(ctx context.Context, accessToken, realm, clientID string, role Role) error
+ UpdateRole(ctx context.Context, accessToken, realm, idOfClient string, role Role) error
  UpdateClient(ctx context.Context, accessToken, realm string, updatedClient Client) error
  UpdateClientScope(ctx context.Context, accessToken, realm string, scope ClientScope) error
 
  DeleteUser(ctx context.Context, accessToken, realm, userID string) error
  DeleteComponent(ctx context.Context, accessToken, realm, componentID string) error
  DeleteGroup(ctx context.Context, accessToken, realm, groupID string) error
- DeleteClientRole(ctx context.Context, accessToken, realm, clientID, roleName string) error
- DeleteClientRoleFromUser(ctx context.Context, token, realm, clientID, userID string, roles []Role) error
- DeleteClient(ctx context.Context, accessToken, realm, clientID string) error
+ DeleteClientRole(ctx context.Context, accessToken, realm, idOfClient, roleName string) error
+ DeleteClientRoleFromUser(ctx context.Context, token, realm, idOfClient, userID string, roles []Role) error
+ DeleteClient(ctx context.Context, accessToken, realm, idOfClient string) error
  DeleteClientScope(ctx context.Context, accessToken, realm, scopeID string) error
- DeleteClientScopeMappingsRealmRoles(ctx context.Context, token, realm, clientID string, roles []Role) error
- DeleteClientScopeMappingsClientRoles(ctx context.Context, token, realm, clientID, clientsID string, roles []Role) error
+ DeleteClientScopeMappingsRealmRoles(ctx context.Context, token, realm, idOfClient string, roles []Role) error
+ DeleteClientScopeMappingsClientRoles(ctx context.Context, token, realm, idOfClient, idOfSelectedClient string, roles []Role) error
 
- GetClient(ctx context.Context, accessToken, realm, clientID string) (*Client, error)
- GetClientsDefaultScopes(ctx context.Context, token, realm, clientID string) ([]*ClientScope, error)
- AddDefaultScopeToClient(ctx context.Context, token, realm, clientID, scopeID string) error
- RemoveDefaultScopeFromClient(ctx context.Context, token, realm, clientID, scopeID string) error
- GetClientsOptionalScopes(ctx context.Context, token, realm, clientID string) ([]*ClientScope, error)
- AddOptionalScopeToClient(ctx context.Context, token, realm, clientID, scopeID string) error
- RemoveOptionalScopeFromClient(ctx context.Context, token, realm, clientID, scopeID string) error
+ GetClient(ctx context.Context, accessToken, realm, idOfClient string) (*Client, error)
+ GetClientsDefaultScopes(ctx context.Context, token, realm, idOfClient string) ([]*ClientScope, error)
+ AddDefaultScopeToClient(ctx context.Context, token, realm, idOfClient, scopeID string) error
+ RemoveDefaultScopeFromClient(ctx context.Context, token, realm, idOfClient, scopeID string) error
+ GetClientsOptionalScopes(ctx context.Context, token, realm, idOfClient string) ([]*ClientScope, error)
+ AddOptionalScopeToClient(ctx context.Context, token, realm, idOfClient, scopeID string) error
+ RemoveOptionalScopeFromClient(ctx context.Context, token, realm, idOfClient, scopeID string) error
  GetDefaultOptionalClientScopes(ctx context.Context, token, realm string) ([]*ClientScope, error)
  GetDefaultDefaultClientScopes(ctx context.Context, token, realm string) ([]*ClientScope, error)
  GetClientScope(ctx context.Context, token, realm, scopeID string) (*ClientScope, error)
  GetClientScopes(ctx context.Context, token, realm string) ([]*ClientScope, error)
- GetClientScopeMappings(ctx context.Context, token, realm, clientID string) (*MappingsRepresentation, error)
- GetClientScopeMappingsRealmRoles(ctx context.Context, token, realm, clientID string) ([]*Role, error)
- GetClientScopeMappingsRealmRolesAvailable(ctx context.Context, token, realm, clientID string) ([]*Role, error)
- GetClientScopeMappingsClientRoles(ctx context.Context, token, realm, clientID, clientsID string) ([]*Role, error)
- GetClientScopeMappingsClientRolesAvailable(ctx context.Context, token, realm, clientID, clientsID string) ([]*Role, error)
- GetClientSecret(ctx context.Context, token, realm, clientID string) (*CredentialRepresentation, error)
- GetClientServiceAccount(ctx context.Context, token, realm, clientID string) (*User, error)
- RegenerateClientSecret(ctx context.Context, token, realm, clientID string) (*CredentialRepresentation, error)
+ GetClientScopeMappings(ctx context.Context, token, realm, idOfClient string) (*MappingsRepresentation, error)
+ GetClientScopeMappingsRealmRoles(ctx context.Context, token, realm, idOfClient string) ([]*Role, error)
+ GetClientScopeMappingsRealmRolesAvailable(ctx context.Context, token, realm, idOfClient string) ([]*Role, error)
+ GetClientScopeMappingsClientRoles(ctx context.Context, token, realm, idOfClient, idOfSelectedClient string) ([]*Role, error)
+ GetClientScopeMappingsClientRolesAvailable(ctx context.Context, token, realm, idOfClient, idOfSelectedClient string) ([]*Role, error)
+ GetClientSecret(ctx context.Context, token, realm, idOfClient string) (*CredentialRepresentation, error)
+ GetClientServiceAccount(ctx context.Context, token, realm, idOfClient string) (*User, error)
+ RegenerateClientSecret(ctx context.Context, token, realm, idOfClient string) (*CredentialRepresentation, error)
  GetKeyStoreConfig(ctx context.Context, accessToken, realm string) (*KeyStoreConfig, error)
  GetUserByID(ctx context.Context, accessToken, realm, userID string) (*User, error)
  GetUserCount(ctx context.Context, accessToken, realm string, params GetUsersParams) (int, error)
@@ -254,17 +254,17 @@ type GoCloak interface {
  GetGroupMembers(ctx context.Context, accessToken, realm, groupID string, params GetGroupsParams) ([]*User, error)
  GetRoleMappingByGroupID(ctx context.Context, accessToken, realm, groupID string) (*MappingsRepresentation, error)
  GetRoleMappingByUserID(ctx context.Context, accessToken, realm, userID string) (*MappingsRepresentation, error)
- GetClientRoles(ctx context.Context, accessToken, realm, clientID string) ([]*Role, error)
- GetClientRole(ctx context.Context, token, realm, clientID, roleName string) (*Role, error)
+ GetClientRoles(ctx context.Context, accessToken, realm, idOfClient string) ([]*Role, error)
+ GetClientRole(ctx context.Context, token, realm, idOfClient, roleName string) (*Role, error)
  GetClientRoleByID(ctx context.Context, accessToken, realm, roleID string) (*Role, error)
  GetClients(ctx context.Context, accessToken, realm string, params GetClientsParams) ([]*Client, error)
  AddClientRoleComposite(ctx context.Context, token, realm, roleID string, roles []Role) error
  DeleteClientRoleComposite(ctx context.Context, token, realm, roleID string, roles []Role) error
  GetUsersByRoleName(ctx context.Context, token, realm, roleName string) ([]*User, error)
- GetUsersByClientRoleName(ctx context.Context, token, realm, clientID, roleName string, params GetUsersByRoleParams) ([]*User, error)
- CreateClientProtocolMapper(ctx context.Context, token, realm, clientID string, mapper ProtocolMapperRepresentation) (string, error)
- UpdateClientProtocolMapper(ctx context.Context, token, realm, clientID, mapperID string, mapper ProtocolMapperRepresentation) error
- DeleteClientProtocolMapper(ctx context.Context, token, realm, clientID, mapperID string) error
+ GetUsersByClientRoleName(ctx context.Context, token, realm, idOfClient, roleName string, params GetUsersByRoleParams) ([]*User, error)
+ CreateClientProtocolMapper(ctx context.Context, token, realm, idOfClient string, mapper ProtocolMapperRepresentation) (string, error)
+ UpdateClientProtocolMapper(ctx context.Context, token, realm, idOfClient, mapperID string, mapper ProtocolMapperRepresentation) error
+ DeleteClientProtocolMapper(ctx context.Context, token, realm, idOfClient, mapperID string) error
 
  // *** Realm Roles ***
 
@@ -289,16 +289,16 @@ type GoCloak interface {
 
  // *** Client Roles ***
 
- AddClientRoleToUser(ctx context.Context, token, realm, clientID, userID string, roles []Role) error
- AddClientRoleToGroup(ctx context.Context, token, realm, clientID, groupID string, roles []Role) error
- DeleteClientRoleFromGroup(ctx context.Context, token, realm, clientID, groupID string, roles []Role) error
- GetCompositeClientRolesByRoleID(ctx context.Context, token, realm, clientID, roleID string) ([]*Role, error)
- GetClientRolesByUserID(ctx context.Context, token, realm, clientID, userID string) ([]*Role, error)
- GetClientRolesByGroupID(ctx context.Context, token, realm, clientID, groupID string) ([]*Role, error)
- GetCompositeClientRolesByUserID(ctx context.Context, token, realm, clientID, userID string) ([]*Role, error)
- GetCompositeClientRolesByGroupID(ctx context.Context, token, realm, clientID, groupID string) ([]*Role, error)
- GetAvailableClientRolesByUserID(ctx context.Context, token, realm, clientID, userID string) ([]*Role, error)
- GetAvailableClientRolesByGroupID(ctx context.Context, token, realm, clientID, groupID string) ([]*Role, error)
+ AddClientRoleToUser(ctx context.Context, token, realm, idOfClient, userID string, roles []Role) error
+ AddClientRoleToGroup(ctx context.Context, token, realm, idOfClient, groupID string, roles []Role) error
+ DeleteClientRoleFromGroup(ctx context.Context, token, realm, idOfClient, groupID string, roles []Role) error
+ GetCompositeClientRolesByRoleID(ctx context.Context, token, realm, idOfClient, roleID string) ([]*Role, error)
+ GetClientRolesByUserID(ctx context.Context, token, realm, idOfClient, userID string) ([]*Role, error)
+ GetClientRolesByGroupID(ctx context.Context, token, realm, idOfClient, groupID string) ([]*Role, error)
+ GetCompositeClientRolesByUserID(ctx context.Context, token, realm, idOfClient, userID string) ([]*Role, error)
+ GetCompositeClientRolesByGroupID(ctx context.Context, token, realm, idOfClient, groupID string) ([]*Role, error)
+ GetAvailableClientRolesByUserID(ctx context.Context, token, realm, idOfClient, userID string) ([]*Role, error)
+ GetAvailableClientRolesByGroupID(ctx context.Context, token, realm, idOfClient, groupID string) ([]*Role, error)
 
  // *** Realm ***
 
@@ -311,17 +311,17 @@ type GoCloak interface {
  ClearUserCache(ctx context.Context, token, realm string) error
  ClearKeysCache(ctx context.Context, token, realm string) error
 
- GetClientUserSessions(ctx context.Context, token, realm, clientID string) ([]*UserSessionRepresentation, error)
- GetClientOfflineSessions(ctx context.Context, token, realm, clientID string) ([]*UserSessionRepresentation, error)
+ GetClientUserSessions(ctx context.Context, token, realm, idOfClient string) ([]*UserSessionRepresentation, error)
+ GetClientOfflineSessions(ctx context.Context, token, realm, idOfClient string) ([]*UserSessionRepresentation, error)
  GetUserSessions(ctx context.Context, token, realm, userID string) ([]*UserSessionRepresentation, error)
- GetUserOfflineSessionsForClient(ctx context.Context, token, realm, userID, clientID string) ([]*UserSessionRepresentation, error)
+ GetUserOfflineSessionsForClient(ctx context.Context, token, realm, userID, idOfClient string) ([]*UserSessionRepresentation, error)
 
  // *** Protection API ***
- GetResource(ctx context.Context, token, realm, clientID, resourceID string) (*ResourceRepresentation, error)
- GetResources(ctx context.Context, token, realm, clientID string, params GetResourceParams) ([]*ResourceRepresentation, error)
- CreateResource(ctx context.Context, token, realm, clientID string, resource ResourceRepresentation) (*ResourceRepresentation, error)
- UpdateResource(ctx context.Context, token, realm, clientID string, resource ResourceRepresentation) error
- DeleteResource(ctx context.Context, token, realm, clientID, resourceID string) error
+ GetResource(ctx context.Context, token, realm, idOfClient, resourceID string) (*ResourceRepresentation, error)
+ GetResources(ctx context.Context, token, realm, idOfClient string, params GetResourceParams) ([]*ResourceRepresentation, error)
+ CreateResource(ctx context.Context, token, realm, idOfClient string, resource ResourceRepresentation) (*ResourceRepresentation, error)
+ UpdateResource(ctx context.Context, token, realm, idOfClient string, resource ResourceRepresentation) error
+ DeleteResource(ctx context.Context, token, realm, idOfClient, resourceID string) error
 
  GetResourceClient(ctx context.Context, token, realm, resourceID string) (*ResourceRepresentation, error)
  GetResourcesClient(ctx context.Context, token, realm string, params GetResourceParams) ([]*ResourceRepresentation, error)
@@ -329,32 +329,32 @@ type GoCloak interface {
  UpdateResourceClient(ctx context.Context, token, realm string, resource ResourceRepresentation) error
  DeleteResourceClient(ctx context.Context, token, realm, resourceID string) error
 
- GetScope(ctx context.Context, token, realm, clientID, scopeID string) (*ScopeRepresentation, error)
- GetScopes(ctx context.Context, token, realm, clientID string, params GetScopeParams) ([]*ScopeRepresentation, error)
- CreateScope(ctx context.Context, token, realm, clientID string, scope ScopeRepresentation) (*ScopeRepresentation, error)
- UpdateScope(ctx context.Context, token, realm, clientID string, resource ScopeRepresentation) error
- DeleteScope(ctx context.Context, token, realm, clientID, scopeID string) error
+ GetScope(ctx context.Context, token, realm, idOfClient, scopeID string) (*ScopeRepresentation, error)
+ GetScopes(ctx context.Context, token, realm, idOfClient string, params GetScopeParams) ([]*ScopeRepresentation, error)
+ CreateScope(ctx context.Context, token, realm, idOfClient string, scope ScopeRepresentation) (*ScopeRepresentation, error)
+ UpdateScope(ctx context.Context, token, realm, idOfClient string, resource ScopeRepresentation) error
+ DeleteScope(ctx context.Context, token, realm, idOfClient, scopeID string) error
 
- GetPolicy(ctx context.Context, token, realm, clientID, policyID string) (*PolicyRepresentation, error)
- GetPolicies(ctx context.Context, token, realm, clientID string, params GetPolicyParams) ([]*PolicyRepresentation, error)
- CreatePolicy(ctx context.Context, token, realm, clientID string, policy PolicyRepresentation) (*PolicyRepresentation, error)
- UpdatePolicy(ctx context.Context, token, realm, clientID string, policy PolicyRepresentation) error
- DeletePolicy(ctx context.Context, token, realm, clientID, policyID string) error
+ GetPolicy(ctx context.Context, token, realm, idOfClient, policyID string) (*PolicyRepresentation, error)
+ GetPolicies(ctx context.Context, token, realm, idOfClient string, params GetPolicyParams) ([]*PolicyRepresentation, error)
+ CreatePolicy(ctx context.Context, token, realm, idOfClient string, policy PolicyRepresentation) (*PolicyRepresentation, error)
+ UpdatePolicy(ctx context.Context, token, realm, idOfClient string, policy PolicyRepresentation) error
+ DeletePolicy(ctx context.Context, token, realm, idOfClient, policyID string) error
 
- GetResourcePolicy(ctx context.Context, token, realm, permissionID string) (*ResourcePolicyRepresentation, error) 
- GetResourcePolicies(ctx context.Context, token, realm string, params GetResourcePoliciesParams) ([]*ResourcePolicyRepresentation, error) 
- CreateResourcePolicy(ctx context.Context, token, realm, resourceID string, policy ResourcePolicyRepresentation) (*ResourcePolicyRepresentation, error) 
- UpdateResourcePolicy(ctx context.Context, token, realm, permissionID string, policy ResourcePolicyRepresentation) error 
- DeleteResourcePolicy(ctx context.Context, token, realm, permissionID string) error 
+ GetResourcePolicy(ctx context.Context, token, realm, permissionID string) (*ResourcePolicyRepresentation, error)
+ GetResourcePolicies(ctx context.Context, token, realm string, params GetResourcePoliciesParams) ([]*ResourcePolicyRepresentation, error)
+ CreateResourcePolicy(ctx context.Context, token, realm, resourceID string, policy ResourcePolicyRepresentation) (*ResourcePolicyRepresentation, error)
+ UpdateResourcePolicy(ctx context.Context, token, realm, permissionID string, policy ResourcePolicyRepresentation) error
+ DeleteResourcePolicy(ctx context.Context, token, realm, permissionID string) error
 
- GetPermission(ctx context.Context, token, realm, clientID, permissionID string) (*PermissionRepresentation, error)
- GetPermissions(ctx context.Context, token, realm, clientID string, params GetPermissionParams) ([]*PermissionRepresentation, error)
- GetPermissionResources(ctx context.Context, token, realm, clientID, permissionID string) ([]*PermissionResource, error)
- GetPermissionScopes(ctx context.Context, token, realm, clientID, permissionID string) ([]*PermissionScope, error)
- GetDependentPermissions(ctx context.Context, token, realm, clientID, policyID string) ([]*PermissionRepresentation, error)
- CreatePermission(ctx context.Context, token, realm, clientID string, permission PermissionRepresentation) (*PermissionRepresentation, error)
- UpdatePermission(ctx context.Context, token, realm, clientID string, permission PermissionRepresentation) error
- DeletePermission(ctx context.Context, token, realm, clientID, permissionID string) error
+ GetPermission(ctx context.Context, token, realm, idOfClient, permissionID string) (*PermissionRepresentation, error)
+ GetPermissions(ctx context.Context, token, realm, idOfClient string, params GetPermissionParams) ([]*PermissionRepresentation, error)
+ GetPermissionResources(ctx context.Context, token, realm, idOfClient, permissionID string) ([]*PermissionResource, error)
+ GetPermissionScopes(ctx context.Context, token, realm, idOfClient, permissionID string) ([]*PermissionScope, error)
+ GetDependentPermissions(ctx context.Context, token, realm, idOfClient, policyID string) ([]*PermissionRepresentation, error)
+ CreatePermission(ctx context.Context, token, realm, idOfClient string, permission PermissionRepresentation) (*PermissionRepresentation, error)
+ UpdatePermission(ctx context.Context, token, realm, idOfClient string, permission PermissionRepresentation) error
+ DeletePermission(ctx context.Context, token, realm, idOfClient, permissionID string) error
 
  CreatePermissionTicket(ctx context.Context, token, realm string, permissions []CreatePermissionTicketParams) (*PermissionTicketResponseRepresentation, error)
  GrantUserPermission(ctx context.Context, token, realm string, permission PermissionGrantParams) (*PermissionGrantResponseRepresentation, error)

--- a/client.go
+++ b/client.go
@@ -145,7 +145,6 @@ func findUsedKey(usedKeyID string, keys []CertResponseKey) *CertResponseKey {
 
 // NewClient creates a new Client
 func NewClient(basePath string, options ...func(*gocloak)) GoCloak {
-
 	c := gocloak{
 		basePath:    strings.TrimRight(basePath, urlSeparator),
 		restyClient: resty.New(),
@@ -665,10 +664,10 @@ func (client *gocloak) CreateComponent(ctx context.Context, token, realm string,
 	return getID(resp), nil
 }
 
-func (client *gocloak) CreateClient(ctx context.Context, token, realm string, newClient Client) (string, error) {
+func (client *gocloak) CreateClient(ctx context.Context, accessToken, realm string, newClient Client) (string, error) {
 	const errMessage = "could not create client"
 
-	resp, err := client.getRequestWithBearerAuth(ctx, token).
+	resp, err := client.getRequestWithBearerAuth(ctx, accessToken).
 		SetBody(newClient).
 		Post(client.getAdminRealmURL(realm, "clients"))
 
@@ -680,12 +679,12 @@ func (client *gocloak) CreateClient(ctx context.Context, token, realm string, ne
 }
 
 // CreateClientRole creates a new role for a client
-func (client *gocloak) CreateClientRole(ctx context.Context, token, realm, clientID string, role Role) (string, error) {
+func (client *gocloak) CreateClientRole(ctx context.Context, token, realm, idOfClient string, role Role) (string, error) {
 	const errMessage = "could not create client role"
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetBody(role).
-		Post(client.getAdminRealmURL(realm, "clients", clientID, "roles"))
+		Post(client.getAdminRealmURL(realm, "clients", idOfClient, "roles"))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return "", err
@@ -737,12 +736,12 @@ func (client *gocloak) UpdateClient(ctx context.Context, token, realm string, up
 	return checkForError(resp, err, errMessage)
 }
 
-func (client *gocloak) UpdateRole(ctx context.Context, token, realm, clientID string, role Role) error {
+func (client *gocloak) UpdateRole(ctx context.Context, token, realm, idOfClient string, role Role) error {
 	const errMessage = "could not update role"
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetBody(role).
-		Put(client.getAdminRealmURL(realm, "clients", clientID, "roles", PString(role.Name)))
+		Put(client.getAdminRealmURL(realm, "clients", idOfClient, "roles", PString(role.Name)))
 
 	return checkForError(resp, err, errMessage)
 }
@@ -767,11 +766,11 @@ func (client *gocloak) DeleteGroup(ctx context.Context, token, realm, groupID st
 }
 
 // DeleteClient deletes a given client
-func (client *gocloak) DeleteClient(ctx context.Context, token, realm, clientID string) error {
+func (client *gocloak) DeleteClient(ctx context.Context, token, realm, idOfClient string) error {
 	const errMessage = "could not delete client"
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
-		Delete(client.getAdminRealmURL(realm, "clients", clientID))
+		Delete(client.getAdminRealmURL(realm, "clients", idOfClient))
 
 	return checkForError(resp, err, errMessage)
 }
@@ -786,11 +785,11 @@ func (client *gocloak) DeleteComponent(ctx context.Context, token, realm, compon
 }
 
 // DeleteClientRole deletes a given role
-func (client *gocloak) DeleteClientRole(ctx context.Context, token, realm, clientID, roleName string) error {
+func (client *gocloak) DeleteClientRole(ctx context.Context, token, realm, idOfClient, roleName string) error {
 	const errMessage = "could not delete client role"
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
-		Delete(client.getAdminRealmURL(realm, "clients", clientID, "roles", roleName))
+		Delete(client.getAdminRealmURL(realm, "clients", idOfClient, "roles", roleName))
 
 	return checkForError(resp, err, errMessage)
 }
@@ -805,14 +804,14 @@ func (client *gocloak) DeleteClientScope(ctx context.Context, token, realm, scop
 }
 
 // GetClient returns a client
-func (client *gocloak) GetClient(ctx context.Context, token, realm, clientID string) (*Client, error) {
+func (client *gocloak) GetClient(ctx context.Context, token, realm, idOfClient string) (*Client, error) {
 	const errMessage = "could not get client"
 
 	var result Client
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
-		Get(client.getAdminRealmURL(realm, "clients", clientID))
+		Get(client.getAdminRealmURL(realm, "clients", idOfClient))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -822,14 +821,14 @@ func (client *gocloak) GetClient(ctx context.Context, token, realm, clientID str
 }
 
 // GetClientsDefaultScopes returns a list of the client's default scopes
-func (client *gocloak) GetClientsDefaultScopes(ctx context.Context, token, realm, clientID string) ([]*ClientScope, error) {
+func (client *gocloak) GetClientsDefaultScopes(ctx context.Context, token, realm, idOfClient string) ([]*ClientScope, error) {
 	const errMessage = "could not get clients default scopes"
 
 	var result []*ClientScope
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
-		Get(client.getAdminRealmURL(realm, "clients", clientID, "default-client-scopes"))
+		Get(client.getAdminRealmURL(realm, "clients", idOfClient, "default-client-scopes"))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -839,34 +838,34 @@ func (client *gocloak) GetClientsDefaultScopes(ctx context.Context, token, realm
 }
 
 // AddDefaultScopeToClient adds a client scope to the list of client's default scopes
-func (client *gocloak) AddDefaultScopeToClient(ctx context.Context, token, realm, clientID, scopeID string) error {
+func (client *gocloak) AddDefaultScopeToClient(ctx context.Context, token, realm, idOfClient, scopeID string) error {
 	const errMessage = "could not add default scope to client"
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
-		Put(client.getAdminRealmURL(realm, "clients", clientID, "default-client-scopes", scopeID))
+		Put(client.getAdminRealmURL(realm, "clients", idOfClient, "default-client-scopes", scopeID))
 
 	return checkForError(resp, err, errMessage)
 }
 
 // RemoveDefaultScopeFromClient removes a client scope from the list of client's default scopes
-func (client *gocloak) RemoveDefaultScopeFromClient(ctx context.Context, token, realm, clientID, scopeID string) error {
+func (client *gocloak) RemoveDefaultScopeFromClient(ctx context.Context, token, realm, idOfClient, scopeID string) error {
 	const errMessage = "could not remove default scope from client"
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
-		Delete(client.getAdminRealmURL(realm, "clients", clientID, "default-client-scopes", scopeID))
+		Delete(client.getAdminRealmURL(realm, "clients", idOfClient, "default-client-scopes", scopeID))
 
 	return checkForError(resp, err, errMessage)
 }
 
 // GetClientsOptionalScopes returns a list of the client's optional scopes
-func (client *gocloak) GetClientsOptionalScopes(ctx context.Context, token, realm, clientID string) ([]*ClientScope, error) {
+func (client *gocloak) GetClientsOptionalScopes(ctx context.Context, token, realm, idOfClient string) ([]*ClientScope, error) {
 	const errMessage = "could not get clients optional scopes"
 
 	var result []*ClientScope
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
-		Get(client.getAdminRealmURL(realm, "clients", clientID, "optional-client-scopes"))
+		Get(client.getAdminRealmURL(realm, "clients", idOfClient, "optional-client-scopes"))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -876,21 +875,21 @@ func (client *gocloak) GetClientsOptionalScopes(ctx context.Context, token, real
 }
 
 // AddOptionalScopeToClient adds a client scope to the list of client's optional scopes
-func (client *gocloak) AddOptionalScopeToClient(ctx context.Context, token, realm, clientID, scopeID string) error {
+func (client *gocloak) AddOptionalScopeToClient(ctx context.Context, token, realm, idOfClient, scopeID string) error {
 	const errMessage = "could not add optional scope to client"
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
-		Put(client.getAdminRealmURL(realm, "clients", clientID, "optional-client-scopes", scopeID))
+		Put(client.getAdminRealmURL(realm, "clients", idOfClient, "optional-client-scopes", scopeID))
 
 	return checkForError(resp, err, errMessage)
 }
 
 // RemoveOptionalScopeFromClient deletes a client scope from the list of client's optional scopes
-func (client *gocloak) RemoveOptionalScopeFromClient(ctx context.Context, token, realm, clientID, scopeID string) error {
+func (client *gocloak) RemoveOptionalScopeFromClient(ctx context.Context, token, realm, idOfClient, scopeID string) error {
 	const errMessage = "could not remove optional scope from client"
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
-		Delete(client.getAdminRealmURL(realm, "clients", clientID, "optional-client-scopes", scopeID))
+		Delete(client.getAdminRealmURL(realm, "clients", idOfClient, "optional-client-scopes", scopeID))
 
 	return checkForError(resp, err, errMessage)
 }
@@ -964,14 +963,14 @@ func (client *gocloak) GetClientScopes(ctx context.Context, token, realm string)
 }
 
 // GetClientScopeMappings returns all scope mappings for the client
-func (client *gocloak) GetClientScopeMappings(ctx context.Context, token, realm, clientID string) (*MappingsRepresentation, error) {
+func (client *gocloak) GetClientScopeMappings(ctx context.Context, token, realm, idOfClient string) (*MappingsRepresentation, error) {
 	const errMessage = "could not get all scope mappings for the client"
 
 	var result *MappingsRepresentation
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
-		Get(client.getAdminRealmURL(realm, "clients", clientID, "scope-mappings"))
+		Get(client.getAdminRealmURL(realm, "clients", idOfClient, "scope-mappings"))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -981,14 +980,14 @@ func (client *gocloak) GetClientScopeMappings(ctx context.Context, token, realm,
 }
 
 // GetClientScopeMappingsRealmRoles returns realm-level roles associated with the client’s scope
-func (client *gocloak) GetClientScopeMappingsRealmRoles(ctx context.Context, token, realm, clientID string) ([]*Role, error) {
+func (client *gocloak) GetClientScopeMappingsRealmRoles(ctx context.Context, token, realm, idOfClient string) ([]*Role, error) {
 	const errMessage = "could not get realm-level roles with the client’s scope"
 
 	var result []*Role
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
-		Get(client.getAdminRealmURL(realm, "clients", clientID, "scope-mappings", "realm"))
+		Get(client.getAdminRealmURL(realm, "clients", idOfClient, "scope-mappings", "realm"))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -998,14 +997,14 @@ func (client *gocloak) GetClientScopeMappingsRealmRoles(ctx context.Context, tok
 }
 
 // GetClientScopeMappingsRealmRolesAvailable returns realm-level roles that are available to attach to this client’s scope
-func (client *gocloak) GetClientScopeMappingsRealmRolesAvailable(ctx context.Context, token, realm, clientID string) ([]*Role, error) {
+func (client *gocloak) GetClientScopeMappingsRealmRolesAvailable(ctx context.Context, token, realm, idOfClient string) ([]*Role, error) {
 	const errMessage = "could not get available realm-level roles with the client’s scope"
 
 	var result []*Role
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
-		Get(client.getAdminRealmURL(realm, "clients", clientID, "scope-mappings", "realm", "available"))
+		Get(client.getAdminRealmURL(realm, "clients", idOfClient, "scope-mappings", "realm", "available"))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -1015,36 +1014,36 @@ func (client *gocloak) GetClientScopeMappingsRealmRolesAvailable(ctx context.Con
 }
 
 // CreateClientScopeMappingsRealmRoles create realm-level roles to the client’s scope
-func (client *gocloak) CreateClientScopeMappingsRealmRoles(ctx context.Context, token, realm, clientID string, roles []Role) error {
+func (client *gocloak) CreateClientScopeMappingsRealmRoles(ctx context.Context, token, realm, idOfClient string, roles []Role) error {
 	const errMessage = "could not create realm-level roles to the client’s scope"
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetBody(roles).
-		Post(client.getAdminRealmURL(realm, "clients", clientID, "scope-mappings", "realm"))
+		Post(client.getAdminRealmURL(realm, "clients", idOfClient, "scope-mappings", "realm"))
 
 	return checkForError(resp, err, errMessage)
 }
 
 // DeleteClientScopeMappingsRealmRoles deletes realm-level roles from the client’s scope
-func (client *gocloak) DeleteClientScopeMappingsRealmRoles(ctx context.Context, token, realm, clientID string, roles []Role) error {
+func (client *gocloak) DeleteClientScopeMappingsRealmRoles(ctx context.Context, token, realm, idOfClient string, roles []Role) error {
 	const errMessage = "could not delete realm-level roles from the client’s scope"
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetBody(roles).
-		Delete(client.getAdminRealmURL(realm, "clients", clientID, "scope-mappings", "realm"))
+		Delete(client.getAdminRealmURL(realm, "clients", idOfClient, "scope-mappings", "realm"))
 
 	return checkForError(resp, err, errMessage)
 }
 
 // GetClientScopeMappingsClientRoles returns roles associated with a client’s scope
-func (client *gocloak) GetClientScopeMappingsClientRoles(ctx context.Context, token, realm, clientID, clientsID string) ([]*Role, error) {
+func (client *gocloak) GetClientScopeMappingsClientRoles(ctx context.Context, token, realm, idOfClient, idOfSelectedClient string) ([]*Role, error) {
 	const errMessage = "could not get roles associated with a client’s scope"
 
 	var result []*Role
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
-		Get(client.getAdminRealmURL(realm, "clients", clientID, "scope-mappings", "clients", clientsID))
+		Get(client.getAdminRealmURL(realm, "clients", idOfClient, "scope-mappings", "clients", idOfSelectedClient))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -1054,14 +1053,14 @@ func (client *gocloak) GetClientScopeMappingsClientRoles(ctx context.Context, to
 }
 
 // GetClientScopeMappingsClientRolesAvailable returns available roles associated with a client’s scope
-func (client *gocloak) GetClientScopeMappingsClientRolesAvailable(ctx context.Context, token, realm, clientID, clientsID string) ([]*Role, error) {
+func (client *gocloak) GetClientScopeMappingsClientRolesAvailable(ctx context.Context, token, realm, idOfClient, idOfSelectedClient string) ([]*Role, error) {
 	const errMessage = "could not get available roles associated with a client’s scope"
 
 	var result []*Role
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
-		Get(client.getAdminRealmURL(realm, "clients", clientID, "scope-mappings", "clients", clientsID, "available"))
+		Get(client.getAdminRealmURL(realm, "clients", idOfClient, "scope-mappings", "clients", idOfSelectedClient, "available"))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -1071,36 +1070,36 @@ func (client *gocloak) GetClientScopeMappingsClientRolesAvailable(ctx context.Co
 }
 
 // CreateClientScopeMappingsClientRoles creates client-level roles from the client’s scope
-func (client *gocloak) CreateClientScopeMappingsClientRoles(ctx context.Context, token, realm, clientID, clientsID string, roles []Role) error {
+func (client *gocloak) CreateClientScopeMappingsClientRoles(ctx context.Context, token, realm, idOfClient, idOfSelectedClient string, roles []Role) error {
 	const errMessage = "could not create client-level roles from the client’s scope"
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetBody(roles).
-		Post(client.getAdminRealmURL(realm, "clients", clientID, "scope-mappings", "clients", clientsID))
+		Post(client.getAdminRealmURL(realm, "clients", idOfClient, "scope-mappings", "clients", idOfSelectedClient))
 
 	return checkForError(resp, err, errMessage)
 }
 
 // DeleteClientScopeMappingsClientRoles deletes client-level roles from the client’s scope
-func (client *gocloak) DeleteClientScopeMappingsClientRoles(ctx context.Context, token, realm, clientID, clientsID string, roles []Role) error {
+func (client *gocloak) DeleteClientScopeMappingsClientRoles(ctx context.Context, token, realm, idOfClient, idOfSelectedClient string, roles []Role) error {
 	const errMessage = "could not delete client-level roles from the client’s scope"
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetBody(roles).
-		Delete(client.getAdminRealmURL(realm, "clients", clientID, "scope-mappings", "clients", clientsID))
+		Delete(client.getAdminRealmURL(realm, "clients", idOfClient, "scope-mappings", "clients", idOfSelectedClient))
 
 	return checkForError(resp, err, errMessage)
 }
 
 // GetClientSecret returns a client's secret
-func (client *gocloak) GetClientSecret(ctx context.Context, token, realm, clientID string) (*CredentialRepresentation, error) {
+func (client *gocloak) GetClientSecret(ctx context.Context, token, realm, idOfClient string) (*CredentialRepresentation, error) {
 	const errMessage = "could not get client secret"
 
 	var result CredentialRepresentation
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
-		Get(client.getAdminRealmURL(realm, "clients", clientID, "client-secret"))
+		Get(client.getAdminRealmURL(realm, "clients", idOfClient, "client-secret"))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -1110,13 +1109,13 @@ func (client *gocloak) GetClientSecret(ctx context.Context, token, realm, client
 }
 
 // GetClientServiceAccount retrieves the service account "user" for a client if enabled
-func (client *gocloak) GetClientServiceAccount(ctx context.Context, token, realm, clientID string) (*User, error) {
+func (client *gocloak) GetClientServiceAccount(ctx context.Context, token, realm, idOfClient string) (*User, error) {
 	const errMessage = "could not get client service account"
 
 	var result User
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
-		Get(client.getAdminRealmURL(realm, "clients", clientID, "service-account-user"))
+		Get(client.getAdminRealmURL(realm, "clients", idOfClient, "service-account-user"))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -1125,13 +1124,13 @@ func (client *gocloak) GetClientServiceAccount(ctx context.Context, token, realm
 	return &result, nil
 }
 
-func (client *gocloak) RegenerateClientSecret(ctx context.Context, token, realm, clientID string) (*CredentialRepresentation, error) {
+func (client *gocloak) RegenerateClientSecret(ctx context.Context, token, realm, idOfClient string) (*CredentialRepresentation, error) {
 	const errMessage = "could not regenerate client secret"
 
 	var result CredentialRepresentation
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
-		Post(client.getAdminRealmURL(realm, "clients", clientID, "client-secret"))
+		Post(client.getAdminRealmURL(realm, "clients", idOfClient, "client-secret"))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -1141,13 +1140,13 @@ func (client *gocloak) RegenerateClientSecret(ctx context.Context, token, realm,
 }
 
 // GetClientOfflineSessions returns offline sessions associated with the client
-func (client *gocloak) GetClientOfflineSessions(ctx context.Context, token, realm, clientID string) ([]*UserSessionRepresentation, error) {
+func (client *gocloak) GetClientOfflineSessions(ctx context.Context, token, realm, idOfClient string) ([]*UserSessionRepresentation, error) {
 	const errMessage = "could not get client offline sessions"
 
 	var res []*UserSessionRepresentation
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&res).
-		Get(client.getAdminRealmURL(realm, "clients", clientID, "offline-sessions"))
+		Get(client.getAdminRealmURL(realm, "clients", idOfClient, "offline-sessions"))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -1157,13 +1156,13 @@ func (client *gocloak) GetClientOfflineSessions(ctx context.Context, token, real
 }
 
 // GetClientUserSessions returns user sessions associated with the client
-func (client *gocloak) GetClientUserSessions(ctx context.Context, token, realm, clientID string) ([]*UserSessionRepresentation, error) {
+func (client *gocloak) GetClientUserSessions(ctx context.Context, token, realm, idOfClient string) ([]*UserSessionRepresentation, error) {
 	const errMessage = "could not get client user sessions"
 
 	var res []*UserSessionRepresentation
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&res).
-		Get(client.getAdminRealmURL(realm, "clients", clientID, "user-sessions"))
+		Get(client.getAdminRealmURL(realm, "clients", idOfClient, "user-sessions"))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -1173,12 +1172,12 @@ func (client *gocloak) GetClientUserSessions(ctx context.Context, token, realm, 
 }
 
 // CreateClientProtocolMapper creates a protocol mapper in client scope
-func (client *gocloak) CreateClientProtocolMapper(ctx context.Context, token, realm, clientID string, mapper ProtocolMapperRepresentation) (string, error) {
+func (client *gocloak) CreateClientProtocolMapper(ctx context.Context, token, realm, idOfClient string, mapper ProtocolMapperRepresentation) (string, error) {
 	const errMessage = "could not create client protocol mapper"
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetBody(mapper).
-		Post(client.getAdminRealmURL(realm, "clients", clientID, "protocol-mappers", "models"))
+		Post(client.getAdminRealmURL(realm, "clients", idOfClient, "protocol-mappers", "models"))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return "", err
@@ -1188,22 +1187,22 @@ func (client *gocloak) CreateClientProtocolMapper(ctx context.Context, token, re
 }
 
 // UpdateClientProtocolMapper updates a protocol mapper in client scope
-func (client *gocloak) UpdateClientProtocolMapper(ctx context.Context, token, realm, clientID, mapperID string, mapper ProtocolMapperRepresentation) error {
+func (client *gocloak) UpdateClientProtocolMapper(ctx context.Context, token, realm, idOfClient, mapperID string, mapper ProtocolMapperRepresentation) error {
 	const errMessage = "could not update client protocol mapper"
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetBody(mapper).
-		Put(client.getAdminRealmURL(realm, "clients", clientID, "protocol-mappers", "models", mapperID))
+		Put(client.getAdminRealmURL(realm, "clients", idOfClient, "protocol-mappers", "models", mapperID))
 
 	return checkForError(resp, err, errMessage)
 }
 
 // DeleteClientProtocolMapper deletes a protocol mapper in client scope
-func (client *gocloak) DeleteClientProtocolMapper(ctx context.Context, token, realm, clientID, mapperID string) error {
+func (client *gocloak) DeleteClientProtocolMapper(ctx context.Context, token, realm, idOfClient, mapperID string) error {
 	const errMessage = "could not delete client protocol mapper"
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
-		Delete(client.getAdminRealmURL(realm, "clients", clientID, "protocol-mappers", "models", mapperID))
+		Delete(client.getAdminRealmURL(realm, "clients", idOfClient, "protocol-mappers", "models", mapperID))
 
 	return checkForError(resp, err, errMessage)
 }
@@ -1385,13 +1384,13 @@ func (client *gocloak) GetGroupMembers(ctx context.Context, token, realm, groupI
 }
 
 // GetClientRoles get all roles for the given client in realm
-func (client *gocloak) GetClientRoles(ctx context.Context, token, realm, clientID string) ([]*Role, error) {
+func (client *gocloak) GetClientRoles(ctx context.Context, token, realm, idOfClient string) ([]*Role, error) {
 	const errMessage = "could not get client roles"
 
 	var result []*Role
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
-		Get(client.getAdminRealmURL(realm, "clients", clientID, "roles"))
+		Get(client.getAdminRealmURL(realm, "clients", idOfClient, "roles"))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -1417,13 +1416,13 @@ func (client *gocloak) GetClientRoleByID(ctx context.Context, token, realm, role
 }
 
 // GetRealmRolesByUserID returns all client roles assigned to the given user
-func (client *gocloak) GetClientRolesByUserID(ctx context.Context, token, realm, clientID, userID string) ([]*Role, error) {
+func (client *gocloak) GetClientRolesByUserID(ctx context.Context, token, realm, idOfClient, userID string) ([]*Role, error) {
 	const errMessage = "could not client roles by user id"
 
 	var result []*Role
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
-		Get(client.getAdminRealmURL(realm, "users", userID, "role-mappings", "clients", clientID))
+		Get(client.getAdminRealmURL(realm, "users", userID, "role-mappings", "clients", idOfClient))
 
 	if err = checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -1433,13 +1432,13 @@ func (client *gocloak) GetClientRolesByUserID(ctx context.Context, token, realm,
 }
 
 // GetClientRolesByGroupID returns all client roles assigned to the given group
-func (client *gocloak) GetClientRolesByGroupID(ctx context.Context, token, realm, clientID, groupID string) ([]*Role, error) {
+func (client *gocloak) GetClientRolesByGroupID(ctx context.Context, token, realm, idOfClient, groupID string) ([]*Role, error) {
 	const errMessage = "could not get client roles by group id"
 
 	var result []*Role
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
-		Get(client.getAdminRealmURL(realm, "groups", groupID, "role-mappings", "clients", clientID))
+		Get(client.getAdminRealmURL(realm, "groups", groupID, "role-mappings", "clients", idOfClient))
 
 	if err = checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -1449,13 +1448,13 @@ func (client *gocloak) GetClientRolesByGroupID(ctx context.Context, token, realm
 }
 
 // GetCompositeClientRolesByRoleID returns all client composite roles associated with the given client role
-func (client *gocloak) GetCompositeClientRolesByRoleID(ctx context.Context, token, realm, clientID, roleID string) ([]*Role, error) {
+func (client *gocloak) GetCompositeClientRolesByRoleID(ctx context.Context, token, realm, idOfClient, roleID string) ([]*Role, error) {
 	const errMessage = "could not get composite client roles by role id"
 
 	var result []*Role
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
-		Get(client.getAdminRealmURL(realm, "roles-by-id", roleID, "composites", "clients", clientID))
+		Get(client.getAdminRealmURL(realm, "roles-by-id", roleID, "composites", "clients", idOfClient))
 
 	if err = checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -1465,13 +1464,13 @@ func (client *gocloak) GetCompositeClientRolesByRoleID(ctx context.Context, toke
 }
 
 // GetCompositeClientRolesByUserID returns all client roles and composite roles assigned to the given user
-func (client *gocloak) GetCompositeClientRolesByUserID(ctx context.Context, token, realm, clientID, userID string) ([]*Role, error) {
+func (client *gocloak) GetCompositeClientRolesByUserID(ctx context.Context, token, realm, idOfClient, userID string) ([]*Role, error) {
 	const errMessage = "could not get composite client roles by user id"
 
 	var result []*Role
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
-		Get(client.getAdminRealmURL(realm, "users", userID, "role-mappings", "clients", clientID, "composite"))
+		Get(client.getAdminRealmURL(realm, "users", userID, "role-mappings", "clients", idOfClient, "composite"))
 
 	if err = checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -1481,13 +1480,13 @@ func (client *gocloak) GetCompositeClientRolesByUserID(ctx context.Context, toke
 }
 
 // GetAvailableClientRolesByUserID returns all available client roles to the given user
-func (client *gocloak) GetAvailableClientRolesByUserID(ctx context.Context, token, realm, clientID, userID string) ([]*Role, error) {
+func (client *gocloak) GetAvailableClientRolesByUserID(ctx context.Context, token, realm, idOfClient, userID string) ([]*Role, error) {
 	const errMessage = "could not get available client roles by user id"
 
 	var result []*Role
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
-		Get(client.getAdminRealmURL(realm, "users", userID, "role-mappings", "clients", clientID, "available"))
+		Get(client.getAdminRealmURL(realm, "users", userID, "role-mappings", "clients", idOfClient, "available"))
 
 	if err = checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -1497,13 +1496,13 @@ func (client *gocloak) GetAvailableClientRolesByUserID(ctx context.Context, toke
 }
 
 // GetAvailableClientRolesByGroupID returns all available roles to the given group
-func (client *gocloak) GetAvailableClientRolesByGroupID(ctx context.Context, token, realm, clientID, groupID string) ([]*Role, error) {
+func (client *gocloak) GetAvailableClientRolesByGroupID(ctx context.Context, token, realm, idOfClient, groupID string) ([]*Role, error) {
 	const errMessage = "could not get available client roles by user id"
 
 	var result []*Role
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
-		Get(client.getAdminRealmURL(realm, "groups", groupID, "role-mappings", "clients", clientID, "available"))
+		Get(client.getAdminRealmURL(realm, "groups", groupID, "role-mappings", "clients", idOfClient, "available"))
 
 	if err = checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -1513,13 +1512,13 @@ func (client *gocloak) GetAvailableClientRolesByGroupID(ctx context.Context, tok
 }
 
 // GetCompositeClientRolesByGroupID returns all client roles and composite roles assigned to the given group
-func (client *gocloak) GetCompositeClientRolesByGroupID(ctx context.Context, token, realm, clientID, groupID string) ([]*Role, error) {
+func (client *gocloak) GetCompositeClientRolesByGroupID(ctx context.Context, token, realm, idOfClient, groupID string) ([]*Role, error) {
 	const errMessage = "could not get composite client roles by group id"
 
 	var result []*Role
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
-		Get(client.getAdminRealmURL(realm, "groups", groupID, "role-mappings", "clients", clientID, "composite"))
+		Get(client.getAdminRealmURL(realm, "groups", groupID, "role-mappings", "clients", idOfClient, "composite"))
 
 	if err = checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -1529,13 +1528,13 @@ func (client *gocloak) GetCompositeClientRolesByGroupID(ctx context.Context, tok
 }
 
 // GetClientRole get a role for the given client in a realm by role name
-func (client *gocloak) GetClientRole(ctx context.Context, token, realm, clientID, roleName string) (*Role, error) {
+func (client *gocloak) GetClientRole(ctx context.Context, token, realm, idOfClient, roleName string) (*Role, error) {
 	const errMessage = "could not get client role"
 
 	var result Role
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
-		Get(client.getAdminRealmURL(realm, "clients", clientID, "roles", roleName))
+		Get(client.getAdminRealmURL(realm, "clients", idOfClient, "roles", roleName))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -2057,7 +2056,7 @@ func (client *gocloak) GetUsersByRoleName(ctx context.Context, token, realm, rol
 }
 
 // GetUsersByClientRoleName returns all users have a given client role
-func (client *gocloak) GetUsersByClientRoleName(ctx context.Context, token, realm, clientID, roleName string, params GetUsersByRoleParams) ([]*User, error) {
+func (client *gocloak) GetUsersByClientRoleName(ctx context.Context, token, realm, idOfClient, roleName string, params GetUsersByRoleParams) ([]*User, error) {
 	const errMessage = "could not get users by client role name"
 
 	var result []*User
@@ -2069,7 +2068,7 @@ func (client *gocloak) GetUsersByClientRoleName(ctx context.Context, token, real
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
 		SetQueryParams(queryParams).
-		Get(client.getAdminRealmURL(realm, "clients", clientID, "roles", roleName, "users"))
+		Get(client.getAdminRealmURL(realm, "clients", idOfClient, "roles", roleName, "users"))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -2138,13 +2137,13 @@ func (client *gocloak) GetUserSessions(ctx context.Context, token, realm, userID
 }
 
 // GetUserOfflineSessionsForClient returns offline sessions associated with the user and client
-func (client *gocloak) GetUserOfflineSessionsForClient(ctx context.Context, token, realm, userID, clientID string) ([]*UserSessionRepresentation, error) {
+func (client *gocloak) GetUserOfflineSessionsForClient(ctx context.Context, token, realm, userID, idOfClient string) ([]*UserSessionRepresentation, error) {
 	const errMessage = "could not get user offline sessions for client"
 
 	var res []*UserSessionRepresentation
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&res).
-		Get(client.getAdminRealmURL(realm, "users", userID, "offline-sessions", clientID))
+		Get(client.getAdminRealmURL(realm, "users", userID, "offline-sessions", idOfClient))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -2154,45 +2153,45 @@ func (client *gocloak) GetUserOfflineSessionsForClient(ctx context.Context, toke
 }
 
 // AddClientRoleToUser adds client-level role mappings
-func (client *gocloak) AddClientRoleToUser(ctx context.Context, token, realm, clientID, userID string, roles []Role) error {
+func (client *gocloak) AddClientRoleToUser(ctx context.Context, token, realm, idOfClient, userID string, roles []Role) error {
 	const errMessage = "could not add client role to user"
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetBody(roles).
-		Post(client.getAdminRealmURL(realm, "users", userID, "role-mappings", "clients", clientID))
+		Post(client.getAdminRealmURL(realm, "users", userID, "role-mappings", "clients", idOfClient))
 
 	return checkForError(resp, err, errMessage)
 }
 
 // AddClientRoleToGroup adds a client role to the group
-func (client *gocloak) AddClientRoleToGroup(ctx context.Context, token, realm, clientID, groupID string, roles []Role) error {
+func (client *gocloak) AddClientRoleToGroup(ctx context.Context, token, realm, idOfClient, groupID string, roles []Role) error {
 	const errMessage = "could not add client role to group"
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetBody(roles).
-		Post(client.getAdminRealmURL(realm, "groups", groupID, "role-mappings", "clients", clientID))
+		Post(client.getAdminRealmURL(realm, "groups", groupID, "role-mappings", "clients", idOfClient))
 
 	return checkForError(resp, err, errMessage)
 }
 
 // DeleteClientRoleFromUser adds client-level role mappings
-func (client *gocloak) DeleteClientRoleFromUser(ctx context.Context, token, realm, clientID, userID string, roles []Role) error {
+func (client *gocloak) DeleteClientRoleFromUser(ctx context.Context, token, realm, idOfClient, userID string, roles []Role) error {
 	const errMessage = "could not delete client role from user"
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetBody(roles).
-		Delete(client.getAdminRealmURL(realm, "users", userID, "role-mappings", "clients", clientID))
+		Delete(client.getAdminRealmURL(realm, "users", userID, "role-mappings", "clients", idOfClient))
 
 	return checkForError(resp, err, errMessage)
 }
 
 // DeleteClientRoleFromGroup removes a client role from from the group
-func (client *gocloak) DeleteClientRoleFromGroup(ctx context.Context, token, realm, clientID, groupID string, roles []Role) error {
+func (client *gocloak) DeleteClientRoleFromGroup(ctx context.Context, token, realm, idOfClient, groupID string, roles []Role) error {
 	const errMessage = "could not client role from group"
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetBody(roles).
-		Delete(client.getAdminRealmURL(realm, "groups", groupID, "role-mappings", "clients", clientID))
+		Delete(client.getAdminRealmURL(realm, "groups", groupID, "role-mappings", "clients", idOfClient))
 
 	return checkForError(resp, err, errMessage)
 }
@@ -2405,13 +2404,13 @@ func (client *gocloak) GetIdentityProviderMappers(ctx context.Context, token, re
 // ------------------
 
 // GetResource returns a client's resource with the given id, using access token from admin
-func (client *gocloak) GetResource(ctx context.Context, token, realm, clientID, resourceID string) (*ResourceRepresentation, error) {
+func (client *gocloak) GetResource(ctx context.Context, token, realm, idOfClient, resourceID string) (*ResourceRepresentation, error) {
 	const errMessage = "could not get resource"
 
 	var result ResourceRepresentation
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
-		Get(client.getAdminRealmURL(realm, "clients", clientID, "authz", "resource-server", "resource", resourceID))
+		Get(client.getAdminRealmURL(realm, "clients", idOfClient, "authz", "resource-server", "resource", resourceID))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -2429,7 +2428,7 @@ func (client *gocloak) GetResourceClient(ctx context.Context, token, realm, reso
 		SetResult(&result).
 		Get(client.getRealmURL(realm, "authz", "protection", "resource_set", resourceID))
 
-	//http://${host}:${port}/auth/realms/${realm_name}/authz/protection/resource_set/{resource_id}
+	// http://${host}:${port}/auth/realms/${realm_name}/authz/protection/resource_set/{resource_id}
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -2439,7 +2438,7 @@ func (client *gocloak) GetResourceClient(ctx context.Context, token, realm, reso
 }
 
 // GetResources returns resources associated with the client, using access token from admin
-func (client *gocloak) GetResources(ctx context.Context, token, realm, clientID string, params GetResourceParams) ([]*ResourceRepresentation, error) {
+func (client *gocloak) GetResources(ctx context.Context, token, realm, idOfClient string, params GetResourceParams) ([]*ResourceRepresentation, error) {
 	const errMessage = "could not get resources"
 
 	queryParams, err := GetQueryParams(params)
@@ -2451,7 +2450,7 @@ func (client *gocloak) GetResources(ctx context.Context, token, realm, clientID 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
 		SetQueryParams(queryParams).
-		Get(client.getAdminRealmURL(realm, "clients", clientID, "authz", "resource-server", "resource"))
+		Get(client.getAdminRealmURL(realm, "clients", idOfClient, "authz", "resource-server", "resource"))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -2491,7 +2490,7 @@ func (client *gocloak) GetResourcesClient(ctx context.Context, token, realm stri
 }
 
 // UpdateResource updates a resource associated with the client, using access token from admin
-func (client *gocloak) UpdateResource(ctx context.Context, token, realm, clientID string, resource ResourceRepresentation) error {
+func (client *gocloak) UpdateResource(ctx context.Context, token, realm, idOfClient string, resource ResourceRepresentation) error {
 	const errMessage = "could not update resource"
 
 	if NilOrEmpty(resource.ID) {
@@ -2500,7 +2499,7 @@ func (client *gocloak) UpdateResource(ctx context.Context, token, realm, clientI
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetBody(resource).
-		Put(client.getAdminRealmURL(realm, "clients", clientID, "authz", "resource-server", "resource", *(resource.ID)))
+		Put(client.getAdminRealmURL(realm, "clients", idOfClient, "authz", "resource-server", "resource", *(resource.ID)))
 
 	return checkForError(resp, err, errMessage)
 }
@@ -2521,14 +2520,14 @@ func (client *gocloak) UpdateResourceClient(ctx context.Context, token, realm st
 }
 
 // CreateResource creates a resource associated with the client, using access token from admin
-func (client *gocloak) CreateResource(ctx context.Context, token, realm string, clientID string, resource ResourceRepresentation) (*ResourceRepresentation, error) {
+func (client *gocloak) CreateResource(ctx context.Context, token, realm string, idOfClient string, resource ResourceRepresentation) (*ResourceRepresentation, error) {
 	const errMessage = "could not create resource"
 
 	var result ResourceRepresentation
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
 		SetBody(resource).
-		Post(client.getAdminRealmURL(realm, "clients", clientID, "authz", "resource-server", "resource"))
+		Post(client.getAdminRealmURL(realm, "clients", idOfClient, "authz", "resource-server", "resource"))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -2555,11 +2554,11 @@ func (client *gocloak) CreateResourceClient(ctx context.Context, token, realm st
 }
 
 // DeleteResource deletes a resource associated with the client (using an admin token)
-func (client *gocloak) DeleteResource(ctx context.Context, token, realm, clientID, resourceID string) error {
+func (client *gocloak) DeleteResource(ctx context.Context, token, realm, idOfClient, resourceID string) error {
 	const errMessage = "could not delete resource"
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
-		Delete(client.getAdminRealmURL(realm, "clients", clientID, "authz", "resource-server", "resource", resourceID))
+		Delete(client.getAdminRealmURL(realm, "clients", idOfClient, "authz", "resource-server", "resource", resourceID))
 
 	return checkForError(resp, err, errMessage)
 }
@@ -2575,13 +2574,13 @@ func (client *gocloak) DeleteResourceClient(ctx context.Context, token, realm, r
 }
 
 // GetScope returns a client's scope with the given id
-func (client *gocloak) GetScope(ctx context.Context, token, realm, clientID, scopeID string) (*ScopeRepresentation, error) {
+func (client *gocloak) GetScope(ctx context.Context, token, realm, idOfClient, scopeID string) (*ScopeRepresentation, error) {
 	const errMessage = "could not get scope"
 
 	var result ScopeRepresentation
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
-		Get(client.getAdminRealmURL(realm, "clients", clientID, "authz", "resource-server", "scope", scopeID))
+		Get(client.getAdminRealmURL(realm, "clients", idOfClient, "authz", "resource-server", "scope", scopeID))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -2591,7 +2590,7 @@ func (client *gocloak) GetScope(ctx context.Context, token, realm, clientID, sco
 }
 
 // GetScopes returns scopes associated with the client
-func (client *gocloak) GetScopes(ctx context.Context, token, realm, clientID string, params GetScopeParams) ([]*ScopeRepresentation, error) {
+func (client *gocloak) GetScopes(ctx context.Context, token, realm, idOfClient string, params GetScopeParams) ([]*ScopeRepresentation, error) {
 	const errMessage = "could not get scopes"
 
 	queryParams, err := GetQueryParams(params)
@@ -2602,7 +2601,7 @@ func (client *gocloak) GetScopes(ctx context.Context, token, realm, clientID str
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
 		SetQueryParams(queryParams).
-		Get(client.getAdminRealmURL(realm, "clients", clientID, "authz", "resource-server", "scope"))
+		Get(client.getAdminRealmURL(realm, "clients", idOfClient, "authz", "resource-server", "scope"))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -2612,14 +2611,14 @@ func (client *gocloak) GetScopes(ctx context.Context, token, realm, clientID str
 }
 
 // CreateScope creates a scope associated with the client
-func (client *gocloak) CreateScope(ctx context.Context, token, realm, clientID string, scope ScopeRepresentation) (*ScopeRepresentation, error) {
+func (client *gocloak) CreateScope(ctx context.Context, token, realm, idOfClient string, scope ScopeRepresentation) (*ScopeRepresentation, error) {
 	const errMessage = "could not create scope"
 
 	var result ScopeRepresentation
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
 		SetBody(scope).
-		Post(client.getAdminRealmURL(realm, "clients", clientID, "authz", "resource-server", "scope"))
+		Post(client.getAdminRealmURL(realm, "clients", idOfClient, "authz", "resource-server", "scope"))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -2629,7 +2628,7 @@ func (client *gocloak) CreateScope(ctx context.Context, token, realm, clientID s
 }
 
 // UpdateScope updates a scope associated with the client
-func (client *gocloak) UpdateScope(ctx context.Context, token, realm, clientID string, scope ScopeRepresentation) error {
+func (client *gocloak) UpdateScope(ctx context.Context, token, realm, idOfClient string, scope ScopeRepresentation) error {
 	const errMessage = "could not update scope"
 
 	if NilOrEmpty(scope.ID) {
@@ -2638,29 +2637,29 @@ func (client *gocloak) UpdateScope(ctx context.Context, token, realm, clientID s
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetBody(scope).
-		Put(client.getAdminRealmURL(realm, "clients", clientID, "authz", "resource-server", "scope", *(scope.ID)))
+		Put(client.getAdminRealmURL(realm, "clients", idOfClient, "authz", "resource-server", "scope", *(scope.ID)))
 
 	return checkForError(resp, err, errMessage)
 }
 
 // DeleteScope deletes a scope associated with the client
-func (client *gocloak) DeleteScope(ctx context.Context, token, realm, clientID, scopeID string) error {
+func (client *gocloak) DeleteScope(ctx context.Context, token, realm, idOfClient, scopeID string) error {
 	const errMessage = "could not delete scope"
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
-		Delete(client.getAdminRealmURL(realm, "clients", clientID, "authz", "resource-server", "scope", scopeID))
+		Delete(client.getAdminRealmURL(realm, "clients", idOfClient, "authz", "resource-server", "scope", scopeID))
 
 	return checkForError(resp, err, errMessage)
 }
 
 // GetPolicy returns a client's policy with the given id
-func (client *gocloak) GetPolicy(ctx context.Context, token, realm, clientID, policyID string) (*PolicyRepresentation, error) {
+func (client *gocloak) GetPolicy(ctx context.Context, token, realm, idOfClient, policyID string) (*PolicyRepresentation, error) {
 	const errMessage = "could not get policy"
 
 	var result PolicyRepresentation
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
-		Get(client.getAdminRealmURL(realm, "clients", clientID, "authz", "resource-server", "policy", policyID))
+		Get(client.getAdminRealmURL(realm, "clients", idOfClient, "authz", "resource-server", "policy", policyID))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -2670,7 +2669,7 @@ func (client *gocloak) GetPolicy(ctx context.Context, token, realm, clientID, po
 }
 
 // GetPolicies returns policies associated with the client
-func (client *gocloak) GetPolicies(ctx context.Context, token, realm, clientID string, params GetPolicyParams) ([]*PolicyRepresentation, error) {
+func (client *gocloak) GetPolicies(ctx context.Context, token, realm, idOfClient string, params GetPolicyParams) ([]*PolicyRepresentation, error) {
 	const errMessage = "could not get policies"
 
 	queryParams, err := GetQueryParams(params)
@@ -2678,7 +2677,7 @@ func (client *gocloak) GetPolicies(ctx context.Context, token, realm, clientID s
 		return nil, errors.Wrap(err, errMessage)
 	}
 
-	path := []string{"clients", clientID, "authz", "resource-server", "policy"}
+	path := []string{"clients", idOfClient, "authz", "resource-server", "policy"}
 	if !NilOrEmpty(params.Type) {
 		path = append(path, *params.Type)
 	}
@@ -2697,7 +2696,7 @@ func (client *gocloak) GetPolicies(ctx context.Context, token, realm, clientID s
 }
 
 // CreatePolicy creates a policy associated with the client
-func (client *gocloak) CreatePolicy(ctx context.Context, token, realm, clientID string, policy PolicyRepresentation) (*PolicyRepresentation, error) {
+func (client *gocloak) CreatePolicy(ctx context.Context, token, realm, idOfClient string, policy PolicyRepresentation) (*PolicyRepresentation, error) {
 	const errMessage = "could not create policy"
 
 	if NilOrEmpty(policy.Type) {
@@ -2708,7 +2707,7 @@ func (client *gocloak) CreatePolicy(ctx context.Context, token, realm, clientID 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
 		SetBody(policy).
-		Post(client.getAdminRealmURL(realm, "clients", clientID, "authz", "resource-server", "policy", *(policy.Type)))
+		Post(client.getAdminRealmURL(realm, "clients", idOfClient, "authz", "resource-server", "policy", *(policy.Type)))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -2718,7 +2717,7 @@ func (client *gocloak) CreatePolicy(ctx context.Context, token, realm, clientID 
 }
 
 // UpdatePolicy updates a policy associated with the client
-func (client *gocloak) UpdatePolicy(ctx context.Context, token, realm, clientID string, policy PolicyRepresentation) error {
+func (client *gocloak) UpdatePolicy(ctx context.Context, token, realm, idOfClient string, policy PolicyRepresentation) error {
 	const errMessage = "could not update policy"
 
 	if NilOrEmpty(policy.ID) {
@@ -2727,17 +2726,17 @@ func (client *gocloak) UpdatePolicy(ctx context.Context, token, realm, clientID 
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetBody(policy).
-		Put(client.getAdminRealmURL(realm, "clients", clientID, "authz", "resource-server", "policy", *(policy.ID)))
+		Put(client.getAdminRealmURL(realm, "clients", idOfClient, "authz", "resource-server", "policy", *(policy.ID)))
 
 	return checkForError(resp, err, errMessage)
 }
 
 // DeletePolicy deletes a policy associated with the client
-func (client *gocloak) DeletePolicy(ctx context.Context, token, realm, clientID, policyID string) error {
+func (client *gocloak) DeletePolicy(ctx context.Context, token, realm, idOfClient, policyID string) error {
 	const errMessage = "could not delete policy"
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
-		Delete(client.getAdminRealmURL(realm, "clients", clientID, "authz", "resource-server", "policy", policyID))
+		Delete(client.getAdminRealmURL(realm, "clients", idOfClient, "authz", "resource-server", "policy", policyID))
 
 	return checkForError(resp, err, errMessage)
 }
@@ -2819,13 +2818,13 @@ func (client *gocloak) DeleteResourcePolicy(ctx context.Context, token, realm, p
 }
 
 // GetPermission returns a client's permission with the given id
-func (client *gocloak) GetPermission(ctx context.Context, token, realm, clientID, permissionID string) (*PermissionRepresentation, error) {
+func (client *gocloak) GetPermission(ctx context.Context, token, realm, idOfClient, permissionID string) (*PermissionRepresentation, error) {
 	const errMessage = "could not get permission"
 
 	var result PermissionRepresentation
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
-		Get(client.getAdminRealmURL(realm, "clients", clientID, "authz", "resource-server", "permission", permissionID))
+		Get(client.getAdminRealmURL(realm, "clients", idOfClient, "authz", "resource-server", "permission", permissionID))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -2835,13 +2834,13 @@ func (client *gocloak) GetPermission(ctx context.Context, token, realm, clientID
 }
 
 // GetDependentPermissions returns a client's permission with the given policy id
-func (client *gocloak) GetDependentPermissions(ctx context.Context, token, realm, clientID, policyID string) ([]*PermissionRepresentation, error) {
+func (client *gocloak) GetDependentPermissions(ctx context.Context, token, realm, idOfClient, policyID string) ([]*PermissionRepresentation, error) {
 	const errMessage = "could not get permission"
 
 	var result []*PermissionRepresentation
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
-		Get(client.getAdminRealmURL(realm, "clients", clientID, "authz", "resource-server", "policy", policyID, "dependentPolicies"))
+		Get(client.getAdminRealmURL(realm, "clients", idOfClient, "authz", "resource-server", "policy", policyID, "dependentPolicies"))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -2851,13 +2850,13 @@ func (client *gocloak) GetDependentPermissions(ctx context.Context, token, realm
 }
 
 // GetPermissionResource returns a client's resource attached for the given permission id
-func (client *gocloak) GetPermissionResources(ctx context.Context, token, realm, clientID, permissionID string) ([]*PermissionResource, error) {
+func (client *gocloak) GetPermissionResources(ctx context.Context, token, realm, idOfClient, permissionID string) ([]*PermissionResource, error) {
 	const errMessage = "could not get permission resource"
 
 	var result []*PermissionResource
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
-		Get(client.getAdminRealmURL(realm, "clients", clientID, "authz", "resource-server", "permission", permissionID, "resources"))
+		Get(client.getAdminRealmURL(realm, "clients", idOfClient, "authz", "resource-server", "permission", permissionID, "resources"))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -2867,13 +2866,13 @@ func (client *gocloak) GetPermissionResources(ctx context.Context, token, realm,
 }
 
 // GetPermissionScopes returns a client's scopes configured for the given permission id
-func (client *gocloak) GetPermissionScopes(ctx context.Context, token, realm, clientID, permissionID string) ([]*PermissionScope, error) {
+func (client *gocloak) GetPermissionScopes(ctx context.Context, token, realm, idOfClient, permissionID string) ([]*PermissionScope, error) {
 	const errMessage = "could not get permission scopes"
 
 	var result []*PermissionScope
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
-		Get(client.getAdminRealmURL(realm, "clients", clientID, "authz", "resource-server", "permission", permissionID, "scopes"))
+		Get(client.getAdminRealmURL(realm, "clients", idOfClient, "authz", "resource-server", "permission", permissionID, "scopes"))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -2883,7 +2882,7 @@ func (client *gocloak) GetPermissionScopes(ctx context.Context, token, realm, cl
 }
 
 // GetPermissions returns permissions associated with the client
-func (client *gocloak) GetPermissions(ctx context.Context, token, realm, clientID string, params GetPermissionParams) ([]*PermissionRepresentation, error) {
+func (client *gocloak) GetPermissions(ctx context.Context, token, realm, idOfClient string, params GetPermissionParams) ([]*PermissionRepresentation, error) {
 	const errMessage = "could not get permissions"
 
 	queryParams, err := GetQueryParams(params)
@@ -2891,7 +2890,7 @@ func (client *gocloak) GetPermissions(ctx context.Context, token, realm, clientI
 		return nil, errors.Wrap(err, errMessage)
 	}
 
-	path := []string{"clients", clientID, "authz", "resource-server", "permission"}
+	path := []string{"clients", idOfClient, "authz", "resource-server", "permission"}
 	if !NilOrEmpty(params.Type) {
 		path = append(path, *params.Type)
 	}
@@ -2911,7 +2910,6 @@ func (client *gocloak) GetPermissions(ctx context.Context, token, realm, clientI
 
 // checkPermissionTicketParams checks that mandatory fields are present
 func checkPermissionTicketParams(permissions []CreatePermissionTicketParams) error {
-
 	if len(permissions) == 0 {
 		return errors.New("at least one permission ticket must be requested")
 	}
@@ -2927,7 +2925,6 @@ func checkPermissionTicketParams(permissions []CreatePermissionTicketParams) err
 	}
 
 	return nil
-
 }
 
 // CreatePermissionTicket creates a permission ticket, using access token from client
@@ -2935,7 +2932,6 @@ func (client *gocloak) CreatePermissionTicket(ctx context.Context, token, realm 
 	const errMessage = "could not create permission ticket"
 
 	err := checkPermissionTicketParams(permissions)
-
 	if err != nil {
 		return nil, err
 	}
@@ -2955,7 +2951,6 @@ func (client *gocloak) CreatePermissionTicket(ctx context.Context, token, realm 
 
 // checkPermissionGrantParams checks for mandatory fields
 func checkPermissionGrantParams(permission PermissionGrantParams) error {
-
 	if NilOrEmpty(permission.RequesterID) {
 		return errors.New("requesterID required to grant user permission")
 	}
@@ -2974,7 +2969,6 @@ func (client *gocloak) GrantUserPermission(ctx context.Context, token, realm str
 	const errMessage = "could not grant user permission"
 
 	err := checkPermissionGrantParams(permission)
-
 	if err != nil {
 		return nil, err
 	}
@@ -2993,14 +2987,11 @@ func (client *gocloak) GrantUserPermission(ctx context.Context, token, realm str
 	}
 
 	return &result, nil
-
 }
 
 // checkPermissionUpdateParams
 func checkPermissionUpdateParams(permission PermissionGrantParams) error {
-
 	err := checkPermissionGrantParams(permission)
-
 	if err != nil {
 		return err
 	}
@@ -3015,7 +3006,6 @@ func (client *gocloak) UpdateUserPermission(ctx context.Context, token, realm st
 	const errMessage = "could not update user permission"
 
 	err := checkPermissionUpdateParams(permission)
-
 	if err != nil {
 		return nil, err
 	}
@@ -3034,8 +3024,8 @@ func (client *gocloak) UpdateUserPermission(ctx context.Context, token, realm st
 	if resp.StatusCode() == http.StatusNoContent { // permission updated to 'not granted' removes permission
 		return nil, nil
 	}
-	return &result, nil
 
+	return &result, nil
 }
 
 // GetUserPermission gets granted permissions according query parameters
@@ -3058,7 +3048,6 @@ func (client *gocloak) GetUserPermissions(ctx context.Context, token, realm stri
 	}
 
 	return result, nil
-
 }
 
 func (client *gocloak) DeleteUserPermission(ctx context.Context, token, realm, ticketID string) error {
@@ -3068,11 +3057,10 @@ func (client *gocloak) DeleteUserPermission(ctx context.Context, token, realm, t
 		Delete(client.getRealmURL(realm, "authz", "protection", "permission", "ticket", ticketID))
 
 	return checkForError(resp, err, errMessage)
-
 }
 
 // CreatePermission creates a permission associated with the client
-func (client *gocloak) CreatePermission(ctx context.Context, token, realm, clientID string, permission PermissionRepresentation) (*PermissionRepresentation, error) {
+func (client *gocloak) CreatePermission(ctx context.Context, token, realm, idOfClient string, permission PermissionRepresentation) (*PermissionRepresentation, error) {
 	const errMessage = "could not create permission"
 
 	if NilOrEmpty(permission.Type) {
@@ -3083,7 +3071,7 @@ func (client *gocloak) CreatePermission(ctx context.Context, token, realm, clien
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
 		SetBody(permission).
-		Post(client.getAdminRealmURL(realm, "clients", clientID, "authz", "resource-server", "permission", *(permission.Type)))
+		Post(client.getAdminRealmURL(realm, "clients", idOfClient, "authz", "resource-server", "permission", *(permission.Type)))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -3093,7 +3081,7 @@ func (client *gocloak) CreatePermission(ctx context.Context, token, realm, clien
 }
 
 // UpdatePermission updates a permission associated with the client
-func (client *gocloak) UpdatePermission(ctx context.Context, token, realm, clientID string, permission PermissionRepresentation) error {
+func (client *gocloak) UpdatePermission(ctx context.Context, token, realm, idOfClient string, permission PermissionRepresentation) error {
 	const errMessage = "could not update permission"
 
 	if NilOrEmpty(permission.ID) {
@@ -3101,17 +3089,17 @@ func (client *gocloak) UpdatePermission(ctx context.Context, token, realm, clien
 	}
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetBody(permission).
-		Put(client.getAdminRealmURL(realm, "clients", clientID, "authz", "resource-server", "permission", *permission.ID))
+		Put(client.getAdminRealmURL(realm, "clients", idOfClient, "authz", "resource-server", "permission", *permission.ID))
 
 	return checkForError(resp, err, errMessage)
 }
 
 // DeletePermission deletes a policy associated with the client
-func (client *gocloak) DeletePermission(ctx context.Context, token, realm, clientID, permissionID string) error {
+func (client *gocloak) DeletePermission(ctx context.Context, token, realm, idOfClient, permissionID string) error {
 	const errMessage = "could not delete permission"
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
-		Delete(client.getAdminRealmURL(realm, "clients", clientID, "authz", "resource-server", "permission", permissionID))
+		Delete(client.getAdminRealmURL(realm, "clients", idOfClient, "authz", "resource-server", "permission", permissionID))
 
 	return checkForError(resp, err, errMessage)
 }

--- a/client_test.go
+++ b/client_test.go
@@ -191,7 +191,7 @@ func CreateGroup(t *testing.T, client gocloak.GoCloak) (func(), string) {
 	return tearDown, groupID
 }
 
-func CreateResource(t *testing.T, client gocloak.GoCloak, clientID string) (func(), string) {
+func CreateResource(t *testing.T, client gocloak.GoCloak, idOfClient string) (func(), string) {
 	cfg := GetConfig(t)
 	token := GetAdminToken(t, client)
 	resource := gocloak.ResourceRepresentation{
@@ -213,7 +213,7 @@ func CreateResource(t *testing.T, client gocloak.GoCloak, clientID string) (func
 		context.Background(),
 		token.AccessToken,
 		cfg.GoCloak.Realm,
-		clientID,
+		idOfClient,
 		resource)
 	require.NoError(t, err, "CreateResource failed")
 	t.Logf("Created Resource ID: %s ", *(createdResource.ID))
@@ -223,7 +223,7 @@ func CreateResource(t *testing.T, client gocloak.GoCloak, clientID string) (func
 			context.Background(),
 			token.AccessToken,
 			cfg.GoCloak.Realm,
-			clientID,
+			idOfClient,
 			*createdResource.ID)
 		require.NoError(t, err, "DeleteResource failed")
 	}
@@ -311,7 +311,7 @@ func CreateResourceClient(t *testing.T, client gocloak.GoCloak) (func(), string)
 	return tearDown, *createdResource.ID
 }
 
-func CreateScope(t *testing.T, client gocloak.GoCloak, clientID string) (func(), string) {
+func CreateScope(t *testing.T, client gocloak.GoCloak, idOfClient string) (func(), string) {
 	cfg := GetConfig(t)
 	token := GetAdminToken(t, client)
 	scope := gocloak.ScopeRepresentation{
@@ -323,7 +323,7 @@ func CreateScope(t *testing.T, client gocloak.GoCloak, clientID string) (func(),
 		context.Background(),
 		token.AccessToken,
 		cfg.GoCloak.Realm,
-		clientID,
+		idOfClient,
 		scope)
 	require.NoError(t, err, "CreateScope failed")
 	t.Logf("Created Scope ID: %s ", *(createdScope.ID))
@@ -333,21 +333,21 @@ func CreateScope(t *testing.T, client gocloak.GoCloak, clientID string) (func(),
 			context.Background(),
 			token.AccessToken,
 			cfg.GoCloak.Realm,
-			clientID,
+			idOfClient,
 			*createdScope.ID)
 		require.NoError(t, err, "DeleteScope failed")
 	}
 	return tearDown, *createdScope.ID
 }
 
-func CreatePolicy(t *testing.T, client gocloak.GoCloak, clientID string, policy gocloak.PolicyRepresentation) (func(), string) {
+func CreatePolicy(t *testing.T, client gocloak.GoCloak, idOfClient string, policy gocloak.PolicyRepresentation) (func(), string) {
 	cfg := GetConfig(t)
 	token := GetAdminToken(t, client)
 	createdPolicy, err := client.CreatePolicy(
 		context.Background(),
 		token.AccessToken,
 		cfg.GoCloak.Realm,
-		clientID,
+		idOfClient,
 		policy)
 	require.NoError(t, err, "CreatePolicy failed")
 
@@ -358,21 +358,21 @@ func CreatePolicy(t *testing.T, client gocloak.GoCloak, clientID string, policy 
 			context.Background(),
 			token.AccessToken,
 			cfg.GoCloak.Realm,
-			clientID,
+			idOfClient,
 			*createdPolicy.ID)
 		require.NoError(t, err, "DeletePolicy failed")
 	}
 	return tearDown, *createdPolicy.ID
 }
 
-func CreatePermission(t *testing.T, client gocloak.GoCloak, clientID string, permission gocloak.PermissionRepresentation) (func(), string) {
+func CreatePermission(t *testing.T, client gocloak.GoCloak, idOfClient string, permission gocloak.PermissionRepresentation) (func(), string) {
 	cfg := GetConfig(t)
 	token := GetAdminToken(t, client)
 	createdPermission, err := client.CreatePermission(
 		context.Background(),
 		token.AccessToken,
 		cfg.GoCloak.Realm,
-		clientID,
+		idOfClient,
 		permission)
 	require.NoError(t, err, "CreatePermission failed")
 	t.Logf("Created RequestingPartyPermission ID: %s ", *(createdPermission.ID))
@@ -382,7 +382,7 @@ func CreatePermission(t *testing.T, client gocloak.GoCloak, clientID string, per
 			context.Background(),
 			token.AccessToken,
 			cfg.GoCloak.Realm,
-			clientID,
+			idOfClient,
 			*createdPermission.ID)
 		require.NoError(t, err, "DeletePermission failed")
 	}
@@ -561,14 +561,14 @@ func ClearRealmCache(t testing.TB, client gocloak.GoCloak, realm ...string) {
 // -----
 
 func TestGocloak_RestyClient(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	client := NewClientWithDebug(t)
 	restyClient := client.RestyClient()
 	require.NotEqual(t, restyClient, resty.New())
 }
 
 func TestGocloak_SetRestyClient(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	client := NewClientWithDebug(t)
 	newRestyClient := resty.New()
 	client.SetRestyClient(newRestyClient)
@@ -577,7 +577,7 @@ func TestGocloak_SetRestyClient(t *testing.T) {
 }
 
 func TestGocloak_checkForError(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	client := NewClientWithDebug(t)
 	FailRequest(client, nil, 1, 0)
 	_, err := client.Login(context.Background(), "", "", "", "", "")
@@ -590,7 +590,7 @@ func TestGocloak_checkForError(t *testing.T) {
 // ---------
 
 func TestGocloak_GetServerInfo(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
 	serverInfo, err := client.GetServerInfo(
@@ -609,7 +609,7 @@ func TestGocloak_GetServerInfo(t *testing.T) {
 }
 
 func TestGocloak_GetUserInfo(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	SetUpTestUser(t, client)
@@ -630,7 +630,7 @@ func TestGocloak_GetUserInfo(t *testing.T) {
 }
 
 func TestGocloak_GetRawUserInfo(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	SetUpTestUser(t, client)
@@ -646,7 +646,7 @@ func TestGocloak_GetRawUserInfo(t *testing.T) {
 }
 
 func TestGocloak_RetrospectRequestingPartyToken(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	SetUpTestUser(t, client)
@@ -702,7 +702,7 @@ func TestGocloak_RetrospectRequestingPartyToken(t *testing.T) {
 }
 
 func TestGocloak_GetRequestingPartyPermissions(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	SetUpTestUser(t, client)
@@ -748,7 +748,7 @@ func TestGocloak_GetRequestingPartyPermissions(t *testing.T) {
 }
 
 func TestGocloak_GetRequestingPartyPermissionDecision(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	SetUpTestUser(t, client)
@@ -786,7 +786,7 @@ func TestGocloak_GetRequestingPartyPermissionDecision(t *testing.T) {
 }
 
 func TestGocloak_GetCerts(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	certs, err := client.GetCerts(context.Background(), cfg.GoCloak.Realm)
@@ -795,7 +795,7 @@ func TestGocloak_GetCerts(t *testing.T) {
 }
 
 func TestGocloak_LoginClient_UnknownRealm(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	_, err := client.LoginClient(
@@ -808,7 +808,7 @@ func TestGocloak_LoginClient_UnknownRealm(t *testing.T) {
 }
 
 func TestGocloak_GetIssuer(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	issuer, err := client.GetIssuer(context.Background(), cfg.GoCloak.Realm)
@@ -817,7 +817,7 @@ func TestGocloak_GetIssuer(t *testing.T) {
 }
 
 func TestGocloak_RetrospectToken_InactiveToken(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 
@@ -833,7 +833,7 @@ func TestGocloak_RetrospectToken_InactiveToken(t *testing.T) {
 }
 
 func TestGocloak_RetrospectToken(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetClientToken(t, client)
@@ -850,7 +850,7 @@ func TestGocloak_RetrospectToken(t *testing.T) {
 }
 
 func TestGocloak_DecodeAccessToken(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetClientToken(t, client)
@@ -885,7 +885,7 @@ func TestGocloak_DecodeAccessTokenCustomClaims(t *testing.T) {
 }
 
 func TestGocloak_RefreshToken(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	SetUpTestUser(t, client)
@@ -902,7 +902,7 @@ func TestGocloak_RefreshToken(t *testing.T) {
 }
 
 func TestGocloak_UserAttributeContains(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 
 	attributes := map[string][]string{}
 	attributes["foo"] = []string{"bar", "alice", "bob", "roflcopter"}
@@ -913,7 +913,7 @@ func TestGocloak_UserAttributeContains(t *testing.T) {
 }
 
 func TestGocloak_GetKeyStoreConfig(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -927,7 +927,7 @@ func TestGocloak_GetKeyStoreConfig(t *testing.T) {
 }
 
 func TestGocloak_Login(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	SetUpTestUser(t, client)
@@ -942,7 +942,7 @@ func TestGocloak_Login(t *testing.T) {
 }
 
 func TestGocloak_LoginSignedJWT(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	keystore := filepath.Join("testdata", "keystore.p12")
 	f, err := os.Open(keystore)
@@ -989,10 +989,9 @@ func TestGocloak_LoginSignedJWT(t *testing.T) {
 }
 
 func TestGocloak_LoginOtp(t *testing.T) {
-
 	totp := "123456"
 
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	SetUpTestUser(t, client)
@@ -1009,7 +1008,7 @@ func TestGocloak_LoginOtp(t *testing.T) {
 }
 
 func TestGocloak_GetToken(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	SetUpTestUser(t, client)
@@ -1075,7 +1074,7 @@ func TestGocloak_GetRequestingPartyToken(t *testing.T) {
 }
 
 func TestGocloak_LoginClient(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	_, err := client.LoginClient(
@@ -1087,7 +1086,7 @@ func TestGocloak_LoginClient(t *testing.T) {
 }
 
 func TestGocloak_LoginAdmin(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	_, err := client.LoginAdmin(
@@ -1099,7 +1098,7 @@ func TestGocloak_LoginAdmin(t *testing.T) {
 }
 
 func TestGocloak_SetPassword(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -1118,7 +1117,7 @@ func TestGocloak_SetPassword(t *testing.T) {
 }
 
 func TestGocloak_CreateListGetUpdateDeleteGetChildGroup(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -1216,14 +1215,14 @@ func CreateClientRole(t *testing.T, client gocloak.GoCloak) (func(), string) {
 }
 
 func TestGocloak_CreateClientRole(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	client := NewClientWithDebug(t)
 	tearDown, _ := CreateClientRole(t, client)
 	tearDown()
 }
 
 func TestGocloak_GetClientRole(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	client := NewClientWithDebug(t)
 	tearDown, roleName := CreateClientRole(t, client)
 	defer tearDown()
@@ -1295,14 +1294,14 @@ func CreateClientScope(t *testing.T, client gocloak.GoCloak, scope *gocloak.Clie
 }
 
 func TestGocloak_CreateClientScope_DeleteClientScope(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	client := NewClientWithDebug(t)
 	tearDown, _ := CreateClientScope(t, client, nil)
 	tearDown()
 }
 
 func TestGocloak_ListAddRemoveDefaultClientScopes(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -1367,7 +1366,7 @@ func TestGocloak_ListAddRemoveDefaultClientScopes(t *testing.T) {
 }
 
 func TestGocloak_ListAddRemoveOptionalClientScopes(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -1426,7 +1425,7 @@ func TestGocloak_ListAddRemoveOptionalClientScopes(t *testing.T) {
 }
 
 func TestGocloak_GetDefaultOptionalClientScopes(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -1442,7 +1441,7 @@ func TestGocloak_GetDefaultOptionalClientScopes(t *testing.T) {
 }
 
 func TestGocloak_GetDefaultDefaultClientScopes(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -1457,7 +1456,7 @@ func TestGocloak_GetDefaultDefaultClientScopes(t *testing.T) {
 }
 
 func TestGocloak_GetClientScope(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -1478,7 +1477,7 @@ func TestGocloak_GetClientScope(t *testing.T) {
 }
 
 func TestGocloak_GetClientScopes(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -1493,7 +1492,7 @@ func TestGocloak_GetClientScopes(t *testing.T) {
 	require.NotZero(t, len(scopes), "there should be client scopes")
 }
 
-func CreateClientScopeMappingsRealmRoles(t *testing.T, client gocloak.GoCloak, clientID string, roles []gocloak.Role) func() {
+func CreateClientScopeMappingsRealmRoles(t *testing.T, client gocloak.GoCloak, idOfClient string, roles []gocloak.Role) func() {
 	token := GetAdminToken(t, client)
 	cfg := GetConfig(t)
 
@@ -1502,7 +1501,7 @@ func CreateClientScopeMappingsRealmRoles(t *testing.T, client gocloak.GoCloak, c
 		context.Background(),
 		token.AccessToken,
 		cfg.GoCloak.Realm,
-		clientID,
+		idOfClient,
 		roles,
 	)
 	require.NoError(t, err, "CreateClientScopeMappingsRealmRoles failed")
@@ -1512,7 +1511,7 @@ func CreateClientScopeMappingsRealmRoles(t *testing.T, client gocloak.GoCloak, c
 			context.Background(),
 			token.AccessToken,
 			cfg.GoCloak.Realm,
-			clientID,
+			idOfClient,
 			roles,
 		)
 		require.NoError(t, err, "DeleteClientScopeMappingsRealmRoles failed")
@@ -1520,7 +1519,7 @@ func CreateClientScopeMappingsRealmRoles(t *testing.T, client gocloak.GoCloak, c
 	return tearDown
 }
 
-func CreateClientScopeMappingsClientRoles(t *testing.T, client gocloak.GoCloak, clientID, clients string, roles []gocloak.Role) func() {
+func CreateClientScopeMappingsClientRoles(t *testing.T, client gocloak.GoCloak, idOfClient, clients string, roles []gocloak.Role) func() {
 	token := GetAdminToken(t, client)
 	cfg := GetConfig(t)
 
@@ -1529,7 +1528,7 @@ func CreateClientScopeMappingsClientRoles(t *testing.T, client gocloak.GoCloak, 
 		context.Background(),
 		token.AccessToken,
 		cfg.GoCloak.Realm,
-		clientID,
+		idOfClient,
 		clients,
 		roles,
 	)
@@ -1540,7 +1539,7 @@ func CreateClientScopeMappingsClientRoles(t *testing.T, client gocloak.GoCloak, 
 			context.Background(),
 			token.AccessToken,
 			cfg.GoCloak.Realm,
-			clientID,
+			idOfClient,
 			clients,
 			roles,
 		)
@@ -1550,7 +1549,7 @@ func CreateClientScopeMappingsClientRoles(t *testing.T, client gocloak.GoCloak, 
 }
 
 func TestGocloak_ClientScopeMappingsClientRoles(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -1560,7 +1559,7 @@ func TestGocloak_ClientScopeMappingsClientRoles(t *testing.T) {
 		FullScopeAllowed: gocloak.BoolP(false),
 	}
 	// Creating client
-	tearDownClient, clientID := CreateClient(t, client, &testClient)
+	tearDownClient, idOfClient := CreateClient(t, client, &testClient)
 	defer tearDownClient()
 
 	// Creating client roles
@@ -1587,7 +1586,7 @@ func TestGocloak_ClientScopeMappingsClientRoles(t *testing.T) {
 	roles = append(roles, *role)
 
 	// Creating client client roles for client scope mappings
-	tearDownScopeMappingsClientRoles := CreateClientScopeMappingsClientRoles(t, client, clientID, gocloakClientID, roles)
+	tearDownScopeMappingsClientRoles := CreateClientScopeMappingsClientRoles(t, client, idOfClient, gocloakClientID, roles)
 	defer tearDownScopeMappingsClientRoles()
 
 	// Check client roles
@@ -1595,7 +1594,7 @@ func TestGocloak_ClientScopeMappingsClientRoles(t *testing.T) {
 		context.Background(),
 		token.AccessToken,
 		cfg.GoCloak.Realm,
-		clientID,
+		idOfClient,
 		gocloakClientID,
 	)
 	require.NoError(t, err, "GetClientScopeMappingsClientRoles failed")
@@ -1616,7 +1615,7 @@ func TestGocloak_ClientScopeMappingsClientRoles(t *testing.T) {
 		context.Background(),
 		token.AccessToken,
 		cfg.GoCloak.Realm,
-		clientID,
+		idOfClient,
 		gocloakClientID,
 	)
 	require.NoError(t, err, "GetClientScopeMappingsClientRolesAvailable failed")
@@ -1627,7 +1626,7 @@ func TestGocloak_ClientScopeMappingsClientRoles(t *testing.T) {
 }
 
 func TestGocloak_ClientScopeMappingsRealmRoles(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -1637,7 +1636,7 @@ func TestGocloak_ClientScopeMappingsRealmRoles(t *testing.T) {
 		FullScopeAllowed: gocloak.BoolP(false),
 	}
 	// Creating client
-	tearDownClient, clientID := CreateClient(t, client, &testClient)
+	tearDownClient, idOfClient := CreateClient(t, client, &testClient)
 	defer tearDownClient()
 
 	// Creating realm role
@@ -1664,7 +1663,7 @@ func TestGocloak_ClientScopeMappingsRealmRoles(t *testing.T) {
 	roles = append(roles, *role)
 
 	// Creating client realm roles for client scope mappings
-	tearDownScopeMappingsRealmRoles := CreateClientScopeMappingsRealmRoles(t, client, clientID, roles)
+	tearDownScopeMappingsRealmRoles := CreateClientScopeMappingsRealmRoles(t, client, idOfClient, roles)
 	defer tearDownScopeMappingsRealmRoles()
 
 	// Check realm roles
@@ -1672,7 +1671,7 @@ func TestGocloak_ClientScopeMappingsRealmRoles(t *testing.T) {
 		context.Background(),
 		token.AccessToken,
 		cfg.GoCloak.Realm,
-		clientID,
+		idOfClient,
 	)
 	require.NoError(t, err, "GetClientScopeMappingsRealmRoles failed")
 	require.Len(
@@ -1691,7 +1690,7 @@ func TestGocloak_ClientScopeMappingsRealmRoles(t *testing.T) {
 		context.Background(),
 		token.AccessToken,
 		cfg.GoCloak.Realm,
-		clientID,
+		idOfClient,
 	)
 	require.NoError(t, err, "GetClientScopeMappingsRealmRolesAvailable failed")
 	require.Len(
@@ -1701,7 +1700,7 @@ func TestGocloak_ClientScopeMappingsRealmRoles(t *testing.T) {
 }
 
 func TestGocloak_CreateListGetUpdateDeleteClient(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -1797,7 +1796,7 @@ func TestGocloak_CreateListGetUpdateDeleteClient(t *testing.T) {
 }
 
 func TestGocloak_GetGroups(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -1811,7 +1810,7 @@ func TestGocloak_GetGroups(t *testing.T) {
 }
 
 func TestGocloak_GetGroupsFull(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -1844,7 +1843,7 @@ func TestGocloak_GetGroupsFull(t *testing.T) {
 }
 
 func TestGocloak_GetGroupsBriefRepresentation(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -1877,7 +1876,7 @@ func TestGocloak_GetGroupsBriefRepresentation(t *testing.T) {
 }
 
 func TestGocloak_GetGroupFull(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -1899,7 +1898,7 @@ func TestGocloak_GetGroupFull(t *testing.T) {
 }
 
 func TestGocloak_GetGroupMembers(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -1930,7 +1929,7 @@ func TestGocloak_GetGroupMembers(t *testing.T) {
 }
 
 func TestGocloak_ListAddRemoveDefaultGroups(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -1979,7 +1978,7 @@ func TestGocloak_ListAddRemoveDefaultGroups(t *testing.T) {
 }
 
 func TestGocloak_GetClientRoles(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -1995,7 +1994,7 @@ func TestGocloak_GetClientRoles(t *testing.T) {
 }
 
 func TestGocloak_GetRoleMappingByGroupID(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -2012,7 +2011,7 @@ func TestGocloak_GetRoleMappingByGroupID(t *testing.T) {
 }
 
 func TestGocloak_GetRoleMappingByUserID(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -2056,7 +2055,7 @@ func TestGocloak_ExecuteActionsEmail_UpdatePassword(t *testing.T) {
 }
 
 func TestGocloak_Logout(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetUserToken(t, client)
@@ -2071,7 +2070,7 @@ func TestGocloak_Logout(t *testing.T) {
 }
 
 func TestGocloak_LogoutAllSessions(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -2089,7 +2088,7 @@ func TestGocloak_LogoutAllSessions(t *testing.T) {
 }
 
 func TestGocloak_LogoutUserSession(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	uToken := GetUserToken(t, client)
@@ -2105,7 +2104,7 @@ func TestGocloak_LogoutUserSession(t *testing.T) {
 }
 
 func TestGocloak_GetRealm(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -2119,7 +2118,7 @@ func TestGocloak_GetRealm(t *testing.T) {
 }
 
 func TestGocloak_GetRealms(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
 
@@ -2174,14 +2173,14 @@ func CreateRealm(t *testing.T, client gocloak.GoCloak) (func(), string) {
 }
 
 func TestGocloak_CreateRealm(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	client := NewClientWithDebug(t)
 	tearDown, _ := CreateRealm(t, client)
 	defer tearDown()
 }
 
 func TestGocloak_UpdateRealm(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
 
@@ -2203,7 +2202,7 @@ func TestGocloak_UpdateRealm(t *testing.T) {
 }
 
 func TestGocloak_ClearRealmCache(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	client := NewClientWithDebug(t)
 	ClearRealmCache(t, client)
 }
@@ -2240,14 +2239,14 @@ func CreateRealmRole(t *testing.T, client gocloak.GoCloak) (func(), string) {
 }
 
 func TestGocloak_CreateRealmRole(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	client := NewClientWithDebug(t)
 	tearDown, _ := CreateRealmRole(t, client)
 	defer tearDown()
 }
 
 func TestGocloak_GetRealmRole(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -2270,7 +2269,7 @@ func TestGocloak_GetRealmRole(t *testing.T) {
 }
 
 func TestGocloak_GetRealmRoles(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -2287,7 +2286,7 @@ func TestGocloak_GetRealmRoles(t *testing.T) {
 }
 
 func TestGocloak_UpdateRealmRole(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -2323,7 +2322,7 @@ func TestGocloak_UpdateRealmRole(t *testing.T) {
 }
 
 func TestGocloak_DeleteRealmRole(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -2339,7 +2338,7 @@ func TestGocloak_DeleteRealmRole(t *testing.T) {
 }
 
 func TestGocloak_AddRealmRoleToUser_DeleteRealmRoleFromUser(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -2375,7 +2374,7 @@ func TestGocloak_AddRealmRoleToUser_DeleteRealmRoleFromUser(t *testing.T) {
 }
 
 func TestGocloak_AddRealmRoleToGroup_DeleteRealmRoleFromGroup(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -2411,7 +2410,7 @@ func TestGocloak_AddRealmRoleToGroup_DeleteRealmRoleFromGroup(t *testing.T) {
 }
 
 func TestGocloak_GetRealmRolesByUserID(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -2475,7 +2474,7 @@ func TestGocloak_GetRealmRolesByUserID(t *testing.T) {
 }
 
 func TestGocloak_GetRealmRolesByGroupID(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -2515,7 +2514,7 @@ func TestGocloak_GetRealmRolesByGroupID(t *testing.T) {
 }
 
 func TestGocloak_AddRealmRoleComposite_DeleteRealmRoleComposite(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -2594,7 +2593,7 @@ func CreateUser(t *testing.T, client gocloak.GoCloak) (func(), string) {
 }
 
 func TestGocloak_CreateUser(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	client := NewClientWithDebug(t)
 
 	tearDown, _ := CreateUser(t, client)
@@ -2602,7 +2601,7 @@ func TestGocloak_CreateUser(t *testing.T) {
 }
 
 func TestGocloak_CreateUserCustomAttributes(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -2625,7 +2624,7 @@ func TestGocloak_CreateUserCustomAttributes(t *testing.T) {
 }
 
 func TestGocloak_GetUserByID(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -2643,7 +2642,7 @@ func TestGocloak_GetUserByID(t *testing.T) {
 }
 
 func TestGocloak_GetUsers(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -2660,7 +2659,7 @@ func TestGocloak_GetUsers(t *testing.T) {
 }
 
 func TestGocloak_GetUserCount(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -2676,7 +2675,7 @@ func TestGocloak_GetUserCount(t *testing.T) {
 }
 
 func TestGocloak_GetGroupsCount(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -2691,7 +2690,7 @@ func TestGocloak_GetGroupsCount(t *testing.T) {
 }
 
 func TestGocloak_AddUserToGroup(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -2712,7 +2711,7 @@ func TestGocloak_AddUserToGroup(t *testing.T) {
 }
 
 func TestGocloak_DeleteUserFromGroup(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -2740,7 +2739,7 @@ func TestGocloak_DeleteUserFromGroup(t *testing.T) {
 }
 
 func TestGocloak_GetUserGroups(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -2771,7 +2770,7 @@ func TestGocloak_GetUserGroups(t *testing.T) {
 }
 
 func TestGocloak_DeleteUser(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	client := NewClientWithDebug(t)
 
 	tearDown, _ := CreateUser(t, client)
@@ -2779,7 +2778,7 @@ func TestGocloak_DeleteUser(t *testing.T) {
 }
 
 func TestGocloak_UpdateUser(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -2802,7 +2801,7 @@ func TestGocloak_UpdateUser(t *testing.T) {
 }
 
 func TestGocloak_UpdateUserSetEmptyRequiredActions(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -2852,7 +2851,7 @@ func TestGocloak_UpdateUserSetEmptyRequiredActions(t *testing.T) {
 }
 
 func TestGocloak_UpdateUserSetEmptyEmail(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -2884,7 +2883,7 @@ func TestGocloak_UpdateUserSetEmptyEmail(t *testing.T) {
 }
 
 func TestGocloak_GetUsersByRoleName(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -2922,7 +2921,7 @@ func TestGocloak_GetUsersByRoleName(t *testing.T) {
 }
 
 func TestGocloak_GetUsersByClientRoleName(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -2963,7 +2962,7 @@ func TestGocloak_GetUsersByClientRoleName(t *testing.T) {
 }
 
 func TestGocloak_GetUserSessions(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	SetUpTestUser(t, client)
@@ -2991,7 +2990,7 @@ func TestGocloak_GetUserSessions(t *testing.T) {
 }
 
 func TestGocloak_GetUserOfflineSessionsForClient(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	SetUpTestUser(t, client)
@@ -3022,7 +3021,7 @@ func TestGocloak_GetUserOfflineSessionsForClient(t *testing.T) {
 }
 
 func TestGocloak_GetClientUserSessions(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	SetUpTestUser(t, client)
@@ -3063,7 +3062,7 @@ func findProtocolMapperByID(t *testing.T, client *gocloak.Client, id string) *go
 }
 
 func TestGocloak_CreateUpdateDeleteClientProtocolMapper(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	id := GetRandomName("protocol-mapper-id-")
@@ -3161,7 +3160,7 @@ func TestGocloak_CreateUpdateDeleteClientProtocolMapper(t *testing.T) {
 }
 
 func TestGocloak_GetClientOfflineSessions(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	SetUpTestUser(t, client)
@@ -3191,7 +3190,7 @@ func TestGocloak_GetClientOfflineSessions(t *testing.T) {
 }
 
 func TestGoCloak_ClientSecret(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -3209,15 +3208,15 @@ func TestGoCloak_ClientSecret(t *testing.T) {
 		ClientAuthenticatorType: gocloak.StringP("client-secret"),
 	}
 
-	tearDown, clientID := CreateClient(t, client, &testClient)
+	tearDown, idOfClient := CreateClient(t, client, &testClient)
 	defer tearDown()
-	require.Equal(t, *testClient.ID, clientID)
+	require.Equal(t, *testClient.ID, idOfClient)
 
 	oldCreds, err := client.GetClientSecret(
 		context.Background(),
 		token.AccessToken,
 		cfg.GoCloak.Realm,
-		clientID,
+		idOfClient,
 	)
 	require.NoError(t, err, "GetClientSecret failed")
 
@@ -3225,7 +3224,7 @@ func TestGoCloak_ClientSecret(t *testing.T) {
 		context.Background(),
 		token.AccessToken,
 		cfg.GoCloak.Realm,
-		clientID,
+		idOfClient,
 	)
 	require.NoError(t, err, "RegenerateClientSecret failed")
 	require.NotEqual(t, *oldCreds.Value, *regeneratedCreds.Value)
@@ -3234,13 +3233,13 @@ func TestGoCloak_ClientSecret(t *testing.T) {
 		context.Background(),
 		token.AccessToken,
 		cfg.GoCloak.Realm,
-		clientID,
+		idOfClient,
 	)
 	require.NoError(t, err, "DeleteClient failed")
 }
 
 func TestGoCloak_ClientServiceAccount(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -3260,7 +3259,7 @@ func TestGoCloak_ClientServiceAccount(t *testing.T) {
 }
 
 func TestGocloak_AddClientRoleToUser_DeleteClientRoleFromUser(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	SetUpTestUser(t, client)
@@ -3308,7 +3307,7 @@ func TestGocloak_AddClientRoleToUser_DeleteClientRoleFromUser(t *testing.T) {
 }
 
 func TestGocloak_GetClientRolesByUserID(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -3375,7 +3374,7 @@ func TestGocloak_GetClientRolesByUserID(t *testing.T) {
 }
 
 func TestGoCloak_GetAvailableClientRolesByUserID(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -3453,7 +3452,7 @@ func TestGoCloak_GetAvailableClientRolesByUserID(t *testing.T) {
 }
 
 func TestGoCloak_GetAvailableRealmRolesByUserID(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -3526,7 +3525,7 @@ func TestGoCloak_GetAvailableRealmRolesByUserID(t *testing.T) {
 }
 
 func TestGoCloak_GetAvailableClientRolesByGroupID(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -3604,7 +3603,7 @@ func TestGoCloak_GetAvailableClientRolesByGroupID(t *testing.T) {
 }
 
 func TestGoCloak_GetAvailableRealmRolesByGroupID(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -3678,7 +3677,7 @@ func TestGoCloak_GetAvailableRealmRolesByGroupID(t *testing.T) {
 }
 
 func TestGocloak_GetClientRolesByGroupID(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -3704,7 +3703,7 @@ func TestGocloak_GetClientRolesByGroupID(t *testing.T) {
 }
 
 func TestGocloak_AddClientRoleToGroup_DeleteClientRoleFromGroup(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	SetUpTestUser(t, client)
@@ -3756,7 +3755,7 @@ func TestGocloak_AddClientRoleToGroup_DeleteClientRoleFromGroup(t *testing.T) {
 }
 
 func TestGocloak_AddDeleteClientRoleComposite(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -3816,7 +3815,7 @@ func TestGocloak_AddDeleteClientRoleComposite(t *testing.T) {
 }
 
 func TestGocloak_AddDeleteRealmRoleComposite(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -3988,7 +3987,7 @@ func TestGocloak_CreateGetDeleteUserFederatedIdentity(t *testing.T) {
 }
 
 func TestGocloak_CreateDeleteClientScopeWithMappers(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -4294,8 +4293,7 @@ func TestGocloak_CreateProvider(t *testing.T) {
 // -----------------
 
 func TestGocloak_ErrorsCreateListGetUpdateDeleteResourceClient(t *testing.T) {
-
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetClientToken(t, client)
@@ -4342,12 +4340,10 @@ func TestGocloak_ErrorsCreateListGetUpdateDeleteResourceClient(t *testing.T) {
 		emptyResource,
 	)
 	require.Error(t, err, "UpdateResourceClient no error on unauthorized request")
-
 }
 
 func TestGocloak_CreateListGetUpdateDeleteResourceClient(t *testing.T) {
-
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetClientToken(t, client)
@@ -4409,11 +4405,10 @@ func TestGocloak_CreateListGetUpdateDeleteResourceClient(t *testing.T) {
 	)
 	require.NoError(t, err, "GetResource failed")
 	require.Equal(t, *(createdResource.Name), *(updatedResource.Name))
-
 }
 
 func TestGocloak_CreateListGetUpdateDeleteResource(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -4482,7 +4477,7 @@ func TestGocloak_CreateListGetUpdateDeleteResource(t *testing.T) {
 }
 
 func TestGocloak_CreateListGetUpdateDeleteScope(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -4550,7 +4545,7 @@ func TestGocloak_CreateListGetUpdateDeleteScope(t *testing.T) {
 }
 
 func TestGocloak_CreateListGetUpdateDeletePolicy(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -4642,7 +4637,6 @@ func TestGocloak_CreateListGetUpdateDeletePolicy(t *testing.T) {
 }
 
 func TestGocloak_CreateGetUpdateDeleteResourcePolicy(t *testing.T) {
-
 	// parallel is causing intermittent conflict with role-based test GetClientScopeMappingsClientRolesAvailable
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
@@ -4727,11 +4721,10 @@ func TestGocloak_CreateGetUpdateDeleteResourcePolicy(t *testing.T) {
 
 	err = client.DeleteResourcePolicy(context.Background(), token.AccessToken, cfg.GoCloak.Realm, "")
 	require.Error(t, err, "should not delete resource policy without permission ID")
-
 }
 
 func TestGocloak_RolePolicy(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -4763,7 +4756,7 @@ func TestGocloak_RolePolicy(t *testing.T) {
 }
 
 func TestGocloak_JSPolicy(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	client := NewClientWithDebug(t)
 
 	// Create
@@ -4781,7 +4774,7 @@ func TestGocloak_JSPolicy(t *testing.T) {
 }
 
 func TestGocloak_ClientPolicy(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	client := NewClientWithDebug(t)
 
 	// Create
@@ -4800,7 +4793,7 @@ func TestGocloak_ClientPolicy(t *testing.T) {
 }
 
 func TestGocloak_TimePolicy(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	client := NewClientWithDebug(t)
 
 	// Create
@@ -4828,7 +4821,7 @@ func TestGocloak_TimePolicy(t *testing.T) {
 }
 
 func TestGocloak_UserPolicy(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	client := NewClientWithDebug(t)
 
 	tearDownUser, userID := CreateUser(t, client)
@@ -4850,7 +4843,7 @@ func TestGocloak_UserPolicy(t *testing.T) {
 }
 
 func TestGocloak_AggregatedPolicy(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	client := NewClientWithDebug(t)
 
 	tearDownClient, clientPolicyID := CreatePolicy(t, client, gocloakClientID, gocloak.PolicyRepresentation{
@@ -4894,7 +4887,7 @@ func TestGocloak_AggregatedPolicy(t *testing.T) {
 }
 
 func TestGocloak_GroupPolicy(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	client := NewClientWithDebug(t)
 
 	tearDownGroup, groupID := CreateGroup(t, client)
@@ -4918,7 +4911,7 @@ func TestGocloak_GroupPolicy(t *testing.T) {
 }
 
 func TestGocloak_ErrorsGrantGetUpdateDeleteUserPermission(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetClientToken(t, client)
@@ -4980,11 +4973,10 @@ func TestGocloak_ErrorsGrantGetUpdateDeleteUserPermission(t *testing.T) {
 	// Delete
 	err = client.DeleteUserPermission(context.Background(), "", cfg.GoCloak.Realm, "someID")
 	require.Error(t, err, "DeleteUserPermission no error on unauthorized request")
-
 }
 
 func TestGocloak_GrantGetUpdateDeleteUserPermission(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetClientToken(t, client)
@@ -5078,11 +5070,10 @@ func TestGocloak_GrantGetUpdateDeleteUserPermission(t *testing.T) {
 	queried, err = client.GetUserPermissions(context.Background(), token.AccessToken, cfg.GoCloak.Realm, params)
 	require.NoError(t, err, "GetUserPermissions failed")
 	require.Equal(t, 0, len(queried))
-
 }
 
 func TestGocloak_BadCreatePermissionTicket(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetClientToken(t, client)
@@ -5115,11 +5106,10 @@ func TestGocloak_BadCreatePermissionTicket(t *testing.T) {
 
 	_, err = client.CreatePermissionTicket(context.Background(), "", cfg.GoCloak.Realm, []gocloak.CreatePermissionTicketParams{permissions})
 	require.Error(t, err, "CreatePermissionTicket no error on unauthorized access attempt")
-
 }
 
 func TestGocloak_CreatePermissionTicket(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetClientToken(t, client)
@@ -5149,10 +5139,10 @@ func TestGocloak_CreatePermissionTicket(t *testing.T) {
 		return []byte(""), nil
 	})
 
-	//we're expecting validity error because we didn't supply secret
+	// we're expecting validity error because we didn't supply secret
 	require.Equal(t, "token signature is invalid", err.Error())
 
-	claims, ok := pt.Claims.(*gocloak.PermissionTicketRepresentation) //ticketClaims)
+	claims, ok := pt.Claims.(*gocloak.PermissionTicketRepresentation) // ticketClaims)
 	require.Equal(t, true, ok)
 	require.Equal(t, cfg.GoCloak.Realm, *(claims.AZP))
 	require.Equal(t, 1, len(*(claims.Permissions)))
@@ -5160,11 +5150,10 @@ func TestGocloak_CreatePermissionTicket(t *testing.T) {
 	require.Equal(t, 1, len(*(claims.Claims)))
 	require.Equal(t, pushClaims["organization"], (*(claims.Claims))["organization"])
 	require.Equal(t, *permissions.ResourceID, *((*(claims.Permissions))[0].RSID))
-
 }
 
 func TestGocloak_CreateListGetUpdateDeletePermission(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -5291,11 +5280,10 @@ func TestGocloak_CreateListGetUpdateDeletePermission(t *testing.T) {
 
 	require.NoError(t, err, "GetPermissionScopes failed")
 	require.Len(t, permissionScopes, 0, "GetPermissionResource should return exact 0 scopes")
-
 }
 
 func TestGoCloak_CheckError(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -5325,7 +5313,7 @@ func TestGoCloak_CheckError(t *testing.T) {
 // ---------------
 
 func TestGoCloak_GetCredentialRegistrators(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -5340,7 +5328,7 @@ func TestGoCloak_GetCredentialRegistrators(t *testing.T) {
 }
 
 func TestGoCloak_GetConfiguredUserStorageCredentialTypes(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -5357,7 +5345,7 @@ func TestGoCloak_GetConfiguredUserStorageCredentialTypes(t *testing.T) {
 }
 
 func TestGoCloak_GetUpdateLableDeleteCredentials(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -5426,7 +5414,7 @@ func TestGoCloak_GetUpdateLableDeleteCredentials(t *testing.T) {
 func TestGoCloak_DisableAllCredentialsByType(t *testing.T) {
 	// NOTE(svilgelm): I didn't find a way how to properly test this function,
 	// so the test validates that the API call doesn't return an error.
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
@@ -5443,7 +5431,7 @@ func TestGoCloak_DisableAllCredentialsByType(t *testing.T) {
 }
 
 func TestGocloak_TestSetFunctionalOptions(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 
 	cfg := GetConfig(t)
 	gocloak.NewClient(cfg.HostName, gocloak.SetAuthRealms("foo"), gocloak.SetAuthAdminRealms("bar"))
@@ -5482,7 +5470,7 @@ func TestGocloak_GetClientsWithPagination(t *testing.T) {
 }
 
 func TestGocloak_ImportIdentityProviderConfig(t *testing.T) {
-	//t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)

--- a/gocloak.go
+++ b/gocloak.go
@@ -29,7 +29,7 @@ type GoCloak interface {
 	// Logout sends a request to the logout endpoint using refresh token
 	Logout(ctx context.Context, clientID, clientSecret, realm, refreshToken string) error
 	// LogoutPublicClient sends a request to the logout endpoint using refresh token
-	LogoutPublicClient(ctx context.Context, clientID, realm, accessToken, refreshToken string) error
+	LogoutPublicClient(ctx context.Context, idOfClient, realm, accessToken, refreshToken string) error
 	// LogoutAllSessions logs out all sessions of a user given an id
 	LogoutAllSessions(ctx context.Context, accessToken, realm, userID string) error
 	// LogoutUserSessions logs out a single sessions of a user given a session id.
@@ -38,7 +38,7 @@ type GoCloak interface {
 	// LoginClient sends a request to the token endpoint using client credentials
 	LoginClient(ctx context.Context, clientID, clientSecret, realm string) (*JWT, error)
 	// LoginClientSignedJWT performs a login with client credentials and signed jwt claims
-	LoginClientSignedJWT(ctx context.Context, clientID, realm string, key interface{}, signedMethod jwt.SigningMethod, expiresAt *jwt.Time) (*JWT, error)
+	LoginClientSignedJWT(ctx context.Context, idOfClient, realm string, key interface{}, signedMethod jwt.SigningMethod, expiresAt *jwt.Time) (*JWT, error)
 	// LoginAdmin login as admin
 	LoginAdmin(ctx context.Context, username, password, realm string) (*JWT, error)
 	// RefreshToken used to refresh the token
@@ -68,20 +68,20 @@ type GoCloak interface {
 	// CreateChildGroup creates a new child group
 	CreateChildGroup(ctx context.Context, token, realm, groupID string, group Group) (string, error)
 	// CreateClient creates a new client
-	CreateClient(ctx context.Context, accessToken, realm string, clientID Client) (string, error)
+	CreateClient(ctx context.Context, accessToken, realm string, newClient Client) (string, error)
 	// CreateClientScope creates a new clientScope
 	CreateClientScope(ctx context.Context, accessToken, realm string, scope ClientScope) (string, error)
 	// CreateComponent creates a new component
 	CreateComponent(ctx context.Context, accessToken, realm string, component Component) (string, error)
 	// CreateClientScopeMappingsRealmRoles creates realm-level roles to the client’s scope
-	CreateClientScopeMappingsRealmRoles(ctx context.Context, token, realm, clientID string, roles []Role) error
+	CreateClientScopeMappingsRealmRoles(ctx context.Context, token, realm, idOfClient string, roles []Role) error
 	// CreateClientScopeMappingsClientRoles creates client-level roles from the client’s scope
-	CreateClientScopeMappingsClientRoles(ctx context.Context, token, realm, clientID, clientsID string, roles []Role) error
+	CreateClientScopeMappingsClientRoles(ctx context.Context, token, realm, idOfClient, idOfSelectedClient string, roles []Role) error
 
 	// UpdateGroup updates the given group
 	UpdateGroup(ctx context.Context, accessToken, realm string, updatedGroup Group) error
 	// UpdateRole updates the given role
-	UpdateRole(ctx context.Context, accessToken, realm, clientID string, role Role) error
+	UpdateRole(ctx context.Context, accessToken, realm, idOfClient string, role Role) error
 	// UpdateClient updates the given client
 	UpdateClient(ctx context.Context, accessToken, realm string, updatedClient Client) error
 	// UpdateClientScope updates the given clientScope
@@ -92,28 +92,28 @@ type GoCloak interface {
 	// DeleteGroup deletes the given group
 	DeleteGroup(ctx context.Context, accessToken, realm, groupID string) error
 	// DeleteClient deletes the given client
-	DeleteClient(ctx context.Context, accessToken, realm, clientID string) error
+	DeleteClient(ctx context.Context, accessToken, realm, idOfClient string) error
 	// DeleteClientScope
 	DeleteClientScope(ctx context.Context, accessToken, realm, scopeID string) error
 	// DeleteClientScopeMappingsRealmRoles deletes realm-level roles from the client’s scope
-	DeleteClientScopeMappingsRealmRoles(ctx context.Context, token, realm, clientID string, roles []Role) error
+	DeleteClientScopeMappingsRealmRoles(ctx context.Context, token, realm, idOfClient string, roles []Role) error
 	// DeleteClientScopeMappingsClientRoles deletes client-level roles from the client’s scope
-	DeleteClientScopeMappingsClientRoles(ctx context.Context, token, realm, clientID, clientsID string, roles []Role) error
+	DeleteClientScopeMappingsClientRoles(ctx context.Context, token, realm, idOfClient, idOfSelectedClient string, roles []Role) error
 
 	// GetClient returns a client
-	GetClient(ctx context.Context, accessToken, realm, clientID string) (*Client, error)
+	GetClient(ctx context.Context, accessToken, realm, idOfClient string) (*Client, error)
 	// GetClientsDefaultScopes returns a list of the client's default scopes
-	GetClientsDefaultScopes(ctx context.Context, token, realm, clientID string) ([]*ClientScope, error)
+	GetClientsDefaultScopes(ctx context.Context, token, realm, idOfClient string) ([]*ClientScope, error)
 	// AddDefaultScopeToClient adds a client scope to the list of client's default scopes
-	AddDefaultScopeToClient(ctx context.Context, token, realm, clientID, scopeID string) error
+	AddDefaultScopeToClient(ctx context.Context, token, realm, idOfClient, scopeID string) error
 	// RemoveDefaultScopeFromClient removes a client scope from the list of client's default scopes
-	RemoveDefaultScopeFromClient(ctx context.Context, token, realm, clientID, scopeID string) error
+	RemoveDefaultScopeFromClient(ctx context.Context, token, realm, idOfClient, scopeID string) error
 	// GetClientsOptionalScopes returns a list of the client's optional scopes
-	GetClientsOptionalScopes(ctx context.Context, token, realm, clientID string) ([]*ClientScope, error)
+	GetClientsOptionalScopes(ctx context.Context, token, realm, idOfClient string) ([]*ClientScope, error)
 	// AddOptionalScopeToClient adds a client scope to the list of client's optional scopes
-	AddOptionalScopeToClient(ctx context.Context, token, realm, clientID, scopeID string) error
+	AddOptionalScopeToClient(ctx context.Context, token, realm, idOfClient, scopeID string) error
 	// RemoveOptionalScopeFromClient deletes a client scope from the list of client's optional scopes
-	RemoveOptionalScopeFromClient(ctx context.Context, token, realm, clientID, scopeID string) error
+	RemoveOptionalScopeFromClient(ctx context.Context, token, realm, idOfClient, scopeID string) error
 	// GetDefaultOptionalClientScopes returns a list of default realm optional scopes
 	GetDefaultOptionalClientScopes(ctx context.Context, token, realm string) ([]*ClientScope, error)
 	// GetDefaultDefaultClientScopes returns a list of default realm default scopes
@@ -123,21 +123,21 @@ type GoCloak interface {
 	// GetClientScopes returns all client scopes
 	GetClientScopes(ctx context.Context, token, realm string) ([]*ClientScope, error)
 	// GetClientScopeMappings returns all scope mappings for the client
-	GetClientScopeMappings(ctx context.Context, token, realm, clientID string) (*MappingsRepresentation, error)
+	GetClientScopeMappings(ctx context.Context, token, realm, idOfClient string) (*MappingsRepresentation, error)
 	// GetClientScopeMappingsRealmRoles returns realm-level roles associated with the client’s scope
-	GetClientScopeMappingsRealmRoles(ctx context.Context, token, realm, clientID string) ([]*Role, error)
+	GetClientScopeMappingsRealmRoles(ctx context.Context, token, realm, idOfClient string) ([]*Role, error)
 	// GetClientScopeMappingsRealmRolesAvailable returns realm-level roles that are available to attach to this client’s scope
-	GetClientScopeMappingsRealmRolesAvailable(ctx context.Context, token, realm, clientID string) ([]*Role, error)
+	GetClientScopeMappingsRealmRolesAvailable(ctx context.Context, token, realm, idOfClient string) ([]*Role, error)
 	// GetClientScopeMappingsClientRoles returns roles associated with a client’s scope
-	GetClientScopeMappingsClientRoles(ctx context.Context, token, realm, clientID, clientsID string) ([]*Role, error)
+	GetClientScopeMappingsClientRoles(ctx context.Context, token, realm, idOfClient, idOfSelectedClient string) ([]*Role, error)
 	// GetClientScopeMappingsClientRolesAvailable returns available roles associated with a client’s scope
-	GetClientScopeMappingsClientRolesAvailable(ctx context.Context, token, realm, clientID, clientsID string) ([]*Role, error)
+	GetClientScopeMappingsClientRolesAvailable(ctx context.Context, token, realm, idOfClient, idOfSelectedClient string) ([]*Role, error)
 	// GetClientSecret returns a client's secret
-	GetClientSecret(ctx context.Context, token, realm, clientID string) (*CredentialRepresentation, error)
+	GetClientSecret(ctx context.Context, token, realm, idOfClient string) (*CredentialRepresentation, error)
 	// GetClientServiceAccount retrieves the service account "user" for a client if enabled
-	GetClientServiceAccount(ctx context.Context, token, realm, clientID string) (*User, error)
+	GetClientServiceAccount(ctx context.Context, token, realm, idOfClient string) (*User, error)
 	// RegenerateClientSecret creates a new client secret returning the updated CredentialRepresentation
-	RegenerateClientSecret(ctx context.Context, token, realm, clientID string) (*CredentialRepresentation, error)
+	RegenerateClientSecret(ctx context.Context, token, realm, idOfClient string) (*CredentialRepresentation, error)
 	// GetKeyStoreConfig gets the keyStoreConfig
 	GetKeyStoreConfig(ctx context.Context, accessToken, realm string) (*KeyStoreConfig, error)
 	// GetComponents gets components of the given realm
@@ -163,15 +163,15 @@ type GoCloak interface {
 	// GetClients gets the clients in the realm
 	GetClients(ctx context.Context, accessToken, realm string, params GetClientsParams) ([]*Client, error)
 	// GetClientOfflineSessions returns offline sessions associated with the client
-	GetClientOfflineSessions(ctx context.Context, token, realm, clientID string) ([]*UserSessionRepresentation, error)
+	GetClientOfflineSessions(ctx context.Context, token, realm, idOfClient string) ([]*UserSessionRepresentation, error)
 	// GetClientUserSessions returns user sessions associated with the client
-	GetClientUserSessions(ctx context.Context, token, realm, clientID string) ([]*UserSessionRepresentation, error)
+	GetClientUserSessions(ctx context.Context, token, realm, idOfClient string) ([]*UserSessionRepresentation, error)
 	// CreateClientProtocolMapper creates a protocol mapper in client scope
-	CreateClientProtocolMapper(ctx context.Context, token, realm, clientID string, mapper ProtocolMapperRepresentation) (string, error)
+	CreateClientProtocolMapper(ctx context.Context, token, realm, idOfClient string, mapper ProtocolMapperRepresentation) (string, error)
 	// CreateClientProtocolMapper updates a protocol mapper in client scope
-	UpdateClientProtocolMapper(ctx context.Context, token, realm, clientID, mapperID string, mapper ProtocolMapperRepresentation) error
+	UpdateClientProtocolMapper(ctx context.Context, token, realm, idOfClient, mapperID string, mapper ProtocolMapperRepresentation) error
 	// DeleteClientProtocolMapper deletes a protocol mapper in client scope
-	DeleteClientProtocolMapper(ctx context.Context, token, realm, clientID, mapperID string) error
+	DeleteClientProtocolMapper(ctx context.Context, token, realm, idOfClient, mapperID string) error
 
 	// *** Realm Roles ***
 
@@ -215,38 +215,38 @@ type GoCloak interface {
 	// *** Client Roles ***
 
 	// AddClientRoleToUser adds a client role to the user
-	AddClientRoleToUser(ctx context.Context, token, realm, clientID, userID string, roles []Role) error
+	AddClientRoleToUser(ctx context.Context, token, realm, idOfClient, userID string, roles []Role) error
 	// AddClientRoleToGroup adds a client role to the group
-	AddClientRoleToGroup(ctx context.Context, token, realm, clientID, groupID string, roles []Role) error
+	AddClientRoleToGroup(ctx context.Context, token, realm, idOfClient, groupID string, roles []Role) error
 	// CreateClientRole creates a new role for a client
-	CreateClientRole(ctx context.Context, accessToken, realm, clientID string, role Role) (string, error)
+	CreateClientRole(ctx context.Context, accessToken, realm, idOfClient string, role Role) (string, error)
 	// DeleteClientRole deletes the given role
-	DeleteClientRole(ctx context.Context, accessToken, realm, clientID, roleName string) error
+	DeleteClientRole(ctx context.Context, accessToken, realm, idOfClient, roleName string) error
 	// DeleteClientRoleFromUser removes a client role from from the user
-	DeleteClientRoleFromUser(ctx context.Context, token, realm, clientID, userID string, roles []Role) error
+	DeleteClientRoleFromUser(ctx context.Context, token, realm, idOfClient, userID string, roles []Role) error
 	// DeleteClientRoleFromGroup removes a client role from from the group
-	DeleteClientRoleFromGroup(ctx context.Context, token, realm, clientID, groupID string, roles []Role) error
+	DeleteClientRoleFromGroup(ctx context.Context, token, realm, idOfClient, groupID string, roles []Role) error
 	// GetClientRoles gets roles for the given client
-	GetClientRoles(ctx context.Context, accessToken, realm, clientID string) ([]*Role, error)
+	GetClientRoles(ctx context.Context, accessToken, realm, idOfClient string) ([]*Role, error)
 	// GetClientRoleById gets role for the given client using role id
 	GetClientRoleByID(ctx context.Context, accessToken, realm, roleID string) (*Role, error)
 	// GetRealmRolesByUserID returns all client roles assigned to the given user
-	GetClientRolesByUserID(ctx context.Context, token, realm, clientID, userID string) ([]*Role, error)
+	GetClientRolesByUserID(ctx context.Context, token, realm, idOfClient, userID string) ([]*Role, error)
 	// GetClientRolesByGroupID returns all client roles assigned to the given group
-	GetClientRolesByGroupID(ctx context.Context, token, realm, clientID, groupID string) ([]*Role, error)
+	GetClientRolesByGroupID(ctx context.Context, token, realm, idOfClient, groupID string) ([]*Role, error)
 	// GetCompositeClientRolesByRoleID returns all client composite roles associated with the given client role
-	GetCompositeClientRolesByRoleID(ctx context.Context, token, realm, clientID, roleID string) ([]*Role, error)
+	GetCompositeClientRolesByRoleID(ctx context.Context, token, realm, idOfClient, roleID string) ([]*Role, error)
 	// GetCompositeClientRolesByUserID returns all client roles and composite roles assigned to the given user
-	GetCompositeClientRolesByUserID(ctx context.Context, token, realm, clientID, userID string) ([]*Role, error)
+	GetCompositeClientRolesByUserID(ctx context.Context, token, realm, idOfClient, userID string) ([]*Role, error)
 	// GetCompositeClientRolesByGroupID returns all client roles and composite roles assigned to the given group
-	GetCompositeClientRolesByGroupID(ctx context.Context, token, realm, clientID, groupID string) ([]*Role, error)
+	GetCompositeClientRolesByGroupID(ctx context.Context, token, realm, idOfClient, groupID string) ([]*Role, error)
 	// GetAvailableClientRolesByUserID returns all available client roles to the given user
-	GetAvailableClientRolesByUserID(ctx context.Context, token, realm, clientID, userID string) ([]*Role, error)
+	GetAvailableClientRolesByUserID(ctx context.Context, token, realm, idOfClient, userID string) ([]*Role, error)
 	// GetAvailableClientRolesByGroupID returns all available client roles to the given group
-	GetAvailableClientRolesByGroupID(ctx context.Context, token, realm, clientID, groupID string) ([]*Role, error)
+	GetAvailableClientRolesByGroupID(ctx context.Context, token, realm, idOfClient, groupID string) ([]*Role, error)
 
 	// GetClientRole get a role for the given client in a realm by role name
-	GetClientRole(ctx context.Context, token, realm, clientID, roleName string) (*Role, error)
+	GetClientRole(ctx context.Context, token, realm, idOfClient, roleName string) (*Role, error)
 	// AddClientRoleComposite adds roles as composite
 	AddClientRoleComposite(ctx context.Context, token, realm, roleID string, roles []Role) error
 	// DeleteClientRoleComposite deletes composites from a role
@@ -287,7 +287,7 @@ type GoCloak interface {
 	// GetUsersByRoleName returns all users have a given role
 	GetUsersByRoleName(ctx context.Context, token, realm, roleName string) ([]*User, error)
 	// GetUsersByClientRoleName returns all users have a given client role
-	GetUsersByClientRoleName(ctx context.Context, token, realm, clientID, roleName string, params GetUsersByRoleParams) ([]*User, error)
+	GetUsersByClientRoleName(ctx context.Context, token, realm, idOfClient, roleName string, params GetUsersByRoleParams) ([]*User, error)
 	// SetPassword sets a new password for the user with the given id. Needs elevated privileges
 	SetPassword(ctx context.Context, token, userID, realm, password string, temporary bool) error
 	// UpdateUser updates the given user
@@ -299,7 +299,7 @@ type GoCloak interface {
 	// GetUserSessions returns user sessions associated with the user
 	GetUserSessions(ctx context.Context, token, realm, userID string) ([]*UserSessionRepresentation, error)
 	// GetUserOfflineSessionsForClient returns offline sessions associated with the user and client
-	GetUserOfflineSessionsForClient(ctx context.Context, token, realm, userID, clientID string) ([]*UserSessionRepresentation, error)
+	GetUserOfflineSessionsForClient(ctx context.Context, token, realm, userID, idOfClient string) ([]*UserSessionRepresentation, error)
 	// GetUserFederatedIdentities gets all user federated identities
 	GetUserFederatedIdentities(ctx context.Context, token, realm, userID string) ([]*FederatedIdentityRepresentation, error)
 	// CreateUserFederatedIdentity creates an user federated identity
@@ -342,26 +342,26 @@ type GoCloak interface {
 	DeleteResourceClient(ctx context.Context, token, realm, resourceID string) error
 
 	// GetResource returns a client's resource with the given id, using access token from admin
-	GetResource(ctx context.Context, token, realm, clientID, resourceID string) (*ResourceRepresentation, error)
+	GetResource(ctx context.Context, token, realm, idOfClient, resourceID string) (*ResourceRepresentation, error)
 	// GetResources a returns resources associated with the client, using access token from admin
-	GetResources(ctx context.Context, token, realm, clientID string, params GetResourceParams) ([]*ResourceRepresentation, error)
+	GetResources(ctx context.Context, token, realm, idOfClient string, params GetResourceParams) ([]*ResourceRepresentation, error)
 	// CreateResource creates a resource associated with the client, using access token from admin
-	CreateResource(ctx context.Context, token, realm, clientID string, resource ResourceRepresentation) (*ResourceRepresentation, error)
+	CreateResource(ctx context.Context, token, realm, idOfClient string, resource ResourceRepresentation) (*ResourceRepresentation, error)
 	// UpdateResource updates a resource associated with the client, using access token from admin
-	UpdateResource(ctx context.Context, token, realm, clientID string, resource ResourceRepresentation) error
+	UpdateResource(ctx context.Context, token, realm, idOfClient string, resource ResourceRepresentation) error
 	// DeleteResource deletes a resource associated with the client, using access token from admin
-	DeleteResource(ctx context.Context, token, realm, clientID, resourceID string) error
+	DeleteResource(ctx context.Context, token, realm, idOfClient, resourceID string) error
 
 	// GetScope returns a client's scope with the given id, using access token from admin
-	GetScope(ctx context.Context, token, realm, clientID, scopeID string) (*ScopeRepresentation, error)
+	GetScope(ctx context.Context, token, realm, idOfClient, scopeID string) (*ScopeRepresentation, error)
 	// GetScopes returns scopes associated with the client, using access token from admin
-	GetScopes(ctx context.Context, token, realm, clientID string, params GetScopeParams) ([]*ScopeRepresentation, error)
+	GetScopes(ctx context.Context, token, realm, idOfClient string, params GetScopeParams) ([]*ScopeRepresentation, error)
 	// CreateScope creates a scope associated with the client, using access token from admin
-	CreateScope(ctx context.Context, token, realm, clientID string, scope ScopeRepresentation) (*ScopeRepresentation, error)
+	CreateScope(ctx context.Context, token, realm, idOfClient string, scope ScopeRepresentation) (*ScopeRepresentation, error)
 	// UpdateScope updates a scope associated with the client, using access token from admin
-	UpdateScope(ctx context.Context, token, realm, clientID string, resource ScopeRepresentation) error
+	UpdateScope(ctx context.Context, token, realm, idOfClient string, resource ScopeRepresentation) error
 	// DeleteScope deletes a scope associated with the client, using access token from admin
-	DeleteScope(ctx context.Context, token, realm, clientID, scopeID string) error
+	DeleteScope(ctx context.Context, token, realm, idOfClient, scopeID string) error
 
 	// CreatePermissionTicket creates a permission ticket for a resource, using access token from client (typically a resource server)
 	CreatePermissionTicket(ctx context.Context, token, realm string, permissions []CreatePermissionTicketParams) (*PermissionTicketResponseRepresentation, error)
@@ -375,30 +375,30 @@ type GoCloak interface {
 	DeleteUserPermission(ctx context.Context, token, realm, ticketID string) error
 
 	// GetPermission returns a client's permission with the given id
-	GetPermission(ctx context.Context, token, realm, clientID, permissionID string) (*PermissionRepresentation, error)
+	GetPermission(ctx context.Context, token, realm, idOfClient, permissionID string) (*PermissionRepresentation, error)
 	// GetPermissions returns permissions associated with the client
-	GetPermissions(ctx context.Context, token, realm, clientID string, params GetPermissionParams) ([]*PermissionRepresentation, error)
+	GetPermissions(ctx context.Context, token, realm, idOfClient string, params GetPermissionParams) ([]*PermissionRepresentation, error)
 	// CreatePermission creates a permission associated with the client
-	CreatePermission(ctx context.Context, token, realm, clientID string, permission PermissionRepresentation) (*PermissionRepresentation, error)
+	CreatePermission(ctx context.Context, token, realm, idOfClient string, permission PermissionRepresentation) (*PermissionRepresentation, error)
 	// UpdatePermission updates a permission associated with the client
-	UpdatePermission(ctx context.Context, token, realm, clientID string, permission PermissionRepresentation) error
+	UpdatePermission(ctx context.Context, token, realm, idOfClient string, permission PermissionRepresentation) error
 	// DeletePermission deletes a permission associated with the client
-	DeletePermission(ctx context.Context, token, realm, clientID, permissionID string) error
+	DeletePermission(ctx context.Context, token, realm, idOfClient, permissionID string) error
 	// GetDependentPermissions returns client's permissions dependent on the policy with given ID
-	GetDependentPermissions(ctx context.Context, token, realm, clientID, policyID string) ([]*PermissionRepresentation, error)
-	GetPermissionResources(ctx context.Context, token, realm, clientID, permissionID string) ([]*PermissionResource, error)
-	GetPermissionScopes(ctx context.Context, token, realm, clientID, permissionID string) ([]*PermissionScope, error)
+	GetDependentPermissions(ctx context.Context, token, realm, idOfClient, policyID string) ([]*PermissionRepresentation, error)
+	GetPermissionResources(ctx context.Context, token, realm, idOfClient, permissionID string) ([]*PermissionResource, error)
+	GetPermissionScopes(ctx context.Context, token, realm, idOfClient, permissionID string) ([]*PermissionScope, error)
 
 	// GetPolicy returns a client's policy with the given id, using access token from admin
-	GetPolicy(ctx context.Context, token, realm, clientID, policyID string) (*PolicyRepresentation, error)
+	GetPolicy(ctx context.Context, token, realm, idOfClient, policyID string) (*PolicyRepresentation, error)
 	// GetPolicies returns policies associated with the client, using access token from admin
-	GetPolicies(ctx context.Context, token, realm, clientID string, params GetPolicyParams) ([]*PolicyRepresentation, error)
+	GetPolicies(ctx context.Context, token, realm, idOfClient string, params GetPolicyParams) ([]*PolicyRepresentation, error)
 	// CreatePolicy creates a policy associated with the client, using access token from admin
-	CreatePolicy(ctx context.Context, token, realm, clientID string, policy PolicyRepresentation) (*PolicyRepresentation, error)
+	CreatePolicy(ctx context.Context, token, realm, idOfClient string, policy PolicyRepresentation) (*PolicyRepresentation, error)
 	// UpdatePolicy updates a policy associated with the client, using access token from admin
-	UpdatePolicy(ctx context.Context, token, realm, clientID string, policy PolicyRepresentation) error
+	UpdatePolicy(ctx context.Context, token, realm, idOfClient string, policy PolicyRepresentation) error
 	// DeletePolicy deletes a policy associated with the client, using access token from admin
-	DeletePolicy(ctx context.Context, token, realm, clientID, policyID string) error
+	DeletePolicy(ctx context.Context, token, realm, idOfClient, policyID string) error
 
 	// GetResourcePolicy updates a permission for a specifc resource, using token obtained by Resource Owner Password Credentials Grant or Token exchange
 	GetResourcePolicy(ctx context.Context, token, realm, permissionID string) (*ResourcePolicyRepresentation, error)


### PR DESCRIPTION
Take client info below for example:
```json
{
  "access": {…},
  "attributes": {…},
  "authenticationFlowBindingOverrides": {},
  "authorizationServicesEnabled": true,
  "bearerOnly": false,
  "clientAuthenticatorType": "client-secret",
  "clientId": "gocloak",  // clientID
  "consentRequired": false,
  "defaultClientScopes": […],
  "directAccessGrantsEnabled": true,
  "enabled": true,
  "frontchannelLogout": false,
  "fullScopeAllowed": true,
  "id": "937f3445-3c14-410c-be8e-075d54bd0106",  // id of client
  "implicitFlowEnabled": false,
  ...
}
```

* In the SDK, `clientID` "gocloak" and `id of client` "937f3445-3c14-410c-be8e-075d54bd0106" both used clientID variable as function signature, this caused confusions
* For example:
  * In `GetClient(ctx, accessToken, realm, clientID)`, `clientID` should be `id of client`, in the form of UUID: "937f3445-3c14-410c-be8e-075d54bd0106"
  * While `Login(ctx, clientID, clientSecret, realm, username, password)`, `clientID` is "gocloak" in the above example
* This commit clear up confusion of `id of client` and `client_id`'s variable `clientID`

Thanks for your contribution!
Hi, if there is an issue, that your PR adresses, please link it! 
