### PR TITLE
Add support for token exchange login method

### DIFF
--- a/client.go
+++ b/client.go
@@ -531,6 +531,18 @@ func (client *gocloak) LoginClient(ctx context.Context, clientID, clientSecret, 
 	})
 }
 
+// LoginClientTokenExchange will exchange the presented token for a user's token
+// Requires Token-Exchange is enabled: https://www.keycloak.org/docs/latest/securing_apps/index.html#_token-exchange
+func (client *gocloak) LoginClientTokenExchange(ctx context.Context, clientID, clientSecret, realm, token, userID string) (*JWT, error) {
+	return client.GetToken(ctx, realm, TokenOptions{
+		ClientID:         &clientID,
+		ClientSecret:     &clientSecret,
+		GrantType:        StringP("urn:ietf:params:oauth:grant-type:token-exchange"),
+		SubjectToken:     &token,
+		RequestedSubject: &userID,
+	})
+}
+
 // LoginClientSignedJWT performs a login with client credentials and signed jwt claims
 func (client *gocloak) LoginClientSignedJWT(
 	ctx context.Context,

--- a/client.go
+++ b/client.go
@@ -533,13 +533,15 @@ func (client *gocloak) LoginClient(ctx context.Context, clientID, clientSecret, 
 
 // LoginClientTokenExchange will exchange the presented token for a user's token
 // Requires Token-Exchange is enabled: https://www.keycloak.org/docs/latest/securing_apps/index.html#_token-exchange
-func (client *gocloak) LoginClientTokenExchange(ctx context.Context, clientID, clientSecret, realm, token, userID string) (*JWT, error) {
+func (client *gocloak) LoginClientTokenExchange(ctx context.Context, clientID, clientSecret, realm, token, targetClient, userID string) (*JWT, error) {
 	return client.GetToken(ctx, realm, TokenOptions{
-		ClientID:         &clientID,
-		ClientSecret:     &clientSecret,
-		GrantType:        StringP("urn:ietf:params:oauth:grant-type:token-exchange"),
-		SubjectToken:     &token,
-		RequestedSubject: &userID,
+		ClientID:           &clientID,
+		ClientSecret:       &clientSecret,
+		GrantType:          StringP("urn:ietf:params:oauth:grant-type:token-exchange"),
+		SubjectToken:       &token,
+		RequestedTokenType: StringP("urn:ietf:params:oauth:token-type:refresh_token"),
+		Audience:           &targetClient,
+		RequestedSubject:   &userID,
 	})
 }
 

--- a/gocloak.go
+++ b/gocloak.go
@@ -39,7 +39,7 @@ type GoCloak interface {
 	// LoginClient sends a request to the token endpoint using client credentials
 	LoginClient(ctx context.Context, clientID, clientSecret, realm string) (*JWT, error)
 	// LoginClientTokenExchange requests a login on a specified users behalf. Returning a user's tokens.
-	LoginClientTokenExchange(ctx context.Context, clientID, token, clientSecret, realm, userID string) (*JWT, error)
+	LoginClientTokenExchange(ctx context.Context, clientID, token, clientSecret, realm, targetClient, userID string) (*JWT, error)
 	// LoginClientSignedJWT performs a login with client credentials and signed jwt claims
 	LoginClientSignedJWT(ctx context.Context, idOfClient, realm string, key interface{}, signedMethod jwt.SigningMethod, expiresAt *jwt.Time) (*JWT, error)
 	// LoginAdmin login as admin

--- a/gocloak.go
+++ b/gocloak.go
@@ -38,6 +38,8 @@ type GoCloak interface {
 	LogoutUserSession(ctx context.Context, accessToken, realm, session string) error
 	// LoginClient sends a request to the token endpoint using client credentials
 	LoginClient(ctx context.Context, clientID, clientSecret, realm string) (*JWT, error)
+	// LoginClientTokenExchange requests a login on a specified users behalf. Returning a user's tokens.
+	LoginClientTokenExchange(ctx context.Context, clientID, token, clientSecret, realm, userID string) (*JWT, error)
 	// LoginClientSignedJWT performs a login with client credentials and signed jwt claims
 	LoginClientSignedJWT(ctx context.Context, idOfClient, realm string, key interface{}, signedMethod jwt.SigningMethod, expiresAt *jwt.Time) (*JWT, error)
 	// LoginAdmin login as admin

--- a/models.go
+++ b/models.go
@@ -780,6 +780,8 @@ type TokenOptions struct {
 	ClientAssertion     *string   `json:"client_assertion,omitempty"`
 	SubjectToken        *string   `json:"subject_token,omitempty"`
 	RequestedSubject    *string   `json:"requested_subject,omitempty"`
+	Audience            *string   `json:"audience,omitempty"`
+	RequestedTokenType  *string   `json:"requested_token_type,omitempty"`
 }
 
 // FormData returns a map of options to be used in SetFormData function

--- a/models.go
+++ b/models.go
@@ -778,6 +778,8 @@ type TokenOptions struct {
 	Code                *string   `json:"code,omitempty"`
 	ClientAssertionType *string   `json:"client_assertion_type,omitempty"`
 	ClientAssertion     *string   `json:"client_assertion,omitempty"`
+	SubjectToken        *string   `json:"subject_token,omitempty"`
+	RequestedSubject    *string   `json:"requested_subject,omitempty"`
 }
 
 // FormData returns a map of options to be used in SetFormData function


### PR DESCRIPTION
Signed-off-by: Ben Clouser <ben.clouser@toradex.com>

 For your consideration...

 I don't necessarily expect this to get merged as is. This API method requires a feature be enabled in keycloak to allow a token exchange... I am not sure what you do with features like this.

Additionally, since it requires a custom feature in keycloak, i didnt include the test i wrote, since it fails due to 501 (not implemented)

FWIW We use this feature in our keycloak service, so i figured I would try to upstream the feature :shrug: 
