### PR TITLE
add IDPAlias IDPUserID query parameter to GetUsersParams

### DIFF
--- a/models.go
+++ b/models.go
@@ -268,6 +268,7 @@ type GetUsersParams struct {
 	First               *int    `json:"first,string,omitempty"`
 	FirstName           *string `json:"firstName,omitempty"`
 	IDPAlias            *string `json:"idpAlias,omitempty"`
+	IDPUserID           *string `json:"idpUserId,omitempty"`
 	LastName            *string `json:"lastName,omitempty"`
 	Max                 *int    `json:"max,string,omitempty"`
 	Search              *string `json:"search,omitempty"`

--- a/models.go
+++ b/models.go
@@ -267,6 +267,7 @@ type GetUsersParams struct {
 	Exact               *bool   `json:"exact,string,omitempty"`
 	First               *int    `json:"first,string,omitempty"`
 	FirstName           *string `json:"firstName,omitempty"`
+	IDPAlias            *string `json:"idpAlias,omitempty"`
 	LastName            *string `json:"lastName,omitempty"`
 	Max                 *int    `json:"max,string,omitempty"`
 	Search              *string `json:"search,omitempty"`


### PR DESCRIPTION
Hi, thanks for this awesome module!
As I want to do some filtering based on idp aliases, I want to add the `idpAlias` query parameter to the `GetUsersParams` struct.

You can see that this is available in later keycloak versions here: https://www.keycloak.org/docs-api/14.0/rest-api/index.html#_users_resource

Let me know if you have any feedback or considerations.

Thanks & best regards,
Marius
