### PR TITLE
Fixed incorrect json representation of ResourceType in PermissionRepresentation

### DIFF
--- a/models.go
+++ b/models.go
@@ -981,7 +981,7 @@ type PermissionRepresentation struct {
 	Name             *string           `json:"name,omitempty"`
 	Policies         *[]string         `json:"policies,omitempty"`
 	Resources        *[]string         `json:"resources,omitempty"`
-	ResourceType     *string           `json:"resource_type,omitempty"`
+	ResourceType     *string           `json:"resourceType,omitempty"`
 	Scopes           *[]string         `json:"scopes,omitempty"`
 	Type             *string           `json:"type,omitempty"`
 }


### PR DESCRIPTION
ResourceType in PermissionRepresentation should be formatted as lower camel case instead of snake case

Attempting to create a resource based policy that is restricted to a resource type, will result in an unknown_error along with the following error in the keycloak log: 
com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "resource_type"