### PR TITLE
feat: adding APIs handler to fetch policy resources

### DIFF
--- a/client.go
+++ b/client.go
@@ -2913,6 +2913,54 @@ func (client *gocloak) DeletePolicy(ctx context.Context, token, realm, idOfClien
 	return checkForError(resp, err, errMessage)
 }
 
+// GetAuthorizationPolicyAssociatedPolicies returns a client's associated policies of specific policy with the given policy id, using access token from admin
+func (client *gocloak) GetAuthorizationPolicyAssociatedPolicies(ctx context.Context, token, realm, idOfClient, policyID string) ([]*PolicyRepresentation, error) {
+	const errMessage = "could not get policy associated policies"
+
+	var result []*PolicyRepresentation
+	resp, err := client.getRequestWithBearerAuth(ctx, token).
+		SetResult(&result).
+		Get(client.getAdminRealmURL(realm, "clients", idOfClient, "authz", "resource-server", "policy", policyID, "associatedPolicies"))
+
+	if err := checkForError(resp, err, errMessage); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// GetAuthorizationPolicyResources returns a client's resources of specific policy with the given policy id, using access token from admin
+func (client *gocloak) GetAuthorizationPolicyResources(ctx context.Context, token, realm, idOfClient, policyID string) ([]*PolicyResourceRepresentation, error) {
+	const errMessage = "could not get policy resources"
+
+	var result []*PolicyResourceRepresentation
+	resp, err := client.getRequestWithBearerAuth(ctx, token).
+		SetResult(&result).
+		Get(client.getAdminRealmURL(realm, "clients", idOfClient, "authz", "resource-server", "policy", policyID, "resources"))
+
+	if err := checkForError(resp, err, errMessage); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// GetAuthorizationPolicyScopes returns a client's scopes of specific policy with the given policy id, using access token from admin
+func (client *gocloak) GetAuthorizationPolicyScopes(ctx context.Context, token, realm, idOfClient, policyID string) ([]*PolicyScopeRepresentation, error) {
+	const errMessage = "could not get policy scopes"
+
+	var result []*PolicyScopeRepresentation
+	resp, err := client.getRequestWithBearerAuth(ctx, token).
+		SetResult(&result).
+		Get(client.getAdminRealmURL(realm, "clients", idOfClient, "authz", "resource-server", "policy", policyID, "scopes"))
+
+	if err := checkForError(resp, err, errMessage); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 // GetResourcePolicy updates a permission for a specifc resource, using token obtained by Resource Owner Password Credentials Grant or Token exchange
 func (client *gocloak) GetResourcePolicy(ctx context.Context, token, realm, permissionID string) (*ResourcePolicyRepresentation, error) {
 	const errMessage = "could not get resource policy"

--- a/gocloak.go
+++ b/gocloak.go
@@ -424,6 +424,12 @@ type GoCloak interface {
 	UpdatePolicy(ctx context.Context, token, realm, idOfClient string, policy PolicyRepresentation) error
 	// DeletePolicy deletes a policy associated with the client, using access token from admin
 	DeletePolicy(ctx context.Context, token, realm, idOfClient, policyID string) error
+	// GetPolicyAssociatedPolicies returns a client's policy associated policies with the given policy id, using access token from admin
+	GetAuthorizationPolicyAssociatedPolicies(ctx context.Context, token, realm, idOfClient, policyID string) ([]*PolicyRepresentation, error)
+	// GetPolicyResources returns a client's resources of specific policy with the given policy id, using access token from admin
+	GetAuthorizationPolicyResources(ctx context.Context, token, realm, idOfClient, policyID string) ([]*PolicyResourceRepresentation, error)
+	// GetPolicyScopes returns a client's scopes of specific policy with the given policy id, using access token from admin
+	GetAuthorizationPolicyScopes(ctx context.Context, token, realm, idOfClient, policyID string) ([]*PolicyScopeRepresentation, error)
 
 	// GetResourcePolicy updates a permission for a specifc resource, using token obtained by Resource Owner Password Credentials Grant or Token exchange
 	GetResourcePolicy(ctx context.Context, token, realm, permissionID string) (*ResourcePolicyRepresentation, error)

--- a/models.go
+++ b/models.go
@@ -1090,6 +1090,18 @@ type ResourcePolicyRepresentation struct {
 	Type             *string           `json:"type,omitempty"`
 }
 
+// PolicyScopeRepresentation is a representation of a scopes of specific policy
+type PolicyScopeRepresentation struct {
+	ID   *string `json:"id,omitempty"`
+	Name *string `json:"name,omitempty"`
+}
+
+// PolicyResourceRepresentation is a representation of a resource of specific policy
+type PolicyResourceRepresentation struct {
+	ID   *string `json:"_id,omitempty"`
+	Name *string `json:"name,omitempty"`
+}
+
 // GetResourcePoliciesParams is a representation of the query params for getting policies
 type GetResourcePoliciesParams struct {
 	ResourceID *string `json:"resource_id,omitempty"`


### PR DESCRIPTION
1. handle fetch policy resources
2. handle fetch policy scopes
3. handle fetch policy associated policies

Thanks for your contribution!
Hi, if there is an issue, that your PR adresses, please link it! 


Fetch authoriazation policy (resources, scope, associated policies) using keycloak policy APIs Fixes #300
