### PR TITLE
add Users to ResourcePolicyRepresentation

### DIFF
--- a/models.go
+++ b/models.go
@@ -1088,6 +1088,7 @@ type ResourcePolicyRepresentation struct {
 	DecisionStrategy *DecisionStrategy `json:"decisionStrategy,omitempty"`
 	Owner            *string           `json:"owner,omitempty"`
 	Type             *string           `json:"type,omitempty"`
+	Users            *[]string         `json:"users,omitempty"`
 }
 
 // PolicyScopeRepresentation is a representation of a scopes of specific policy


### PR DESCRIPTION
Added missing User-Based Policies ([link](https://www.keycloak.org/docs/latest/authorization_services/index.html#_policy_user)) to the Protection API ([link](https://www.keycloak.org/docs/latest/authorization_services/index.html#_service_protection_api)) methods.
