### PR TITLE
Fix wrong function signature

### DIFF
--- a/client.go
+++ b/client.go
@@ -533,7 +533,7 @@ func (client *gocloak) LoginClient(ctx context.Context, clientID, clientSecret, 
 
 // LoginClientTokenExchange will exchange the presented token for a user's token
 // Requires Token-Exchange is enabled: https://www.keycloak.org/docs/latest/securing_apps/index.html#_token-exchange
-func (client *gocloak) LoginClientTokenExchange(ctx context.Context, clientID, clientSecret, realm, token, targetClient, userID string) (*JWT, error) {
+func (client *gocloak) LoginClientTokenExchange(ctx context.Context, clientID, token, clientSecret, realm, targetClient, userID string) (*JWT, error) {
 	return client.GetToken(ctx, realm, TokenOptions{
 		ClientID:           &clientID,
 		ClientSecret:       &clientSecret,


### PR DESCRIPTION
Fixes an error in the function signature of the LoginClientTokenExchange implementation.
