### PR TITLE
Added ExactName param to GetResourceParams

### DIFF
--- a/models.go
+++ b/models.go
@@ -942,7 +942,7 @@ type GetResourceParams struct {
 	URI         *string `json:"uri,omitempty"`
 	Scope       *string `json:"scope,omitempty"`
 	MatchingURI *bool   `json:"matchingUri,string,omitempty"`
-	ExactName   *bool `json:"exactName,string,omitempty"`
+	ExactName   *bool   `json:"exactName,string,omitempty"`
 }
 
 // GetScopeParams represents the optional parameters for getting scopes


### PR DESCRIPTION
Added exactName parameter when querying for resources, as described in https://github.com/keycloak/keycloak-documentation/blob/master/authorization_services/topics/service-protection-resources-api-papi.adoc#querying-resources