### PR TITLE
Add query parameter search to model GetClientsParams

### DIFF
--- a/models.go
+++ b/models.go
@@ -616,6 +616,7 @@ type GetClientsParams struct {
 	ViewableOnly         *bool   `json:"viewableOnly,string,omitempty"`
 	First                *int    `json:"first,string,omitempty"`
 	Max                  *int    `json:"max,string,omitempty"`
+	Search               *bool   `json:"search,string,omitempty"`
 	SearchableAttributes *string `json:"q,omitempty"`
 }
 


### PR DESCRIPTION
Add query parameter **search** to model GetClientsParams
This parameter support since keycloak 9.0
Api doc: https://www.keycloak.org/docs-api/9.0/rest-api/index.html#_clients_resource