### PR TITLE
change type of enum PolicyEnforcementMode from int to string

### DIFF
--- a/models.go
+++ b/models.go
@@ -476,13 +476,13 @@ type AdapterConfiguration struct {
 }
 
 // PolicyEnforcementMode is an enum type for PolicyEnforcementMode of ResourceServerRepresentation
-type PolicyEnforcementMode int
+type PolicyEnforcementMode string
 
 // PolicyEnforcementMode values
-const (
-	ENFORCING PolicyEnforcementMode = iota
-	PERMISSIVE
-	DISABLED
+var (
+	ENFORCING  = PolicyEnforcementModeP("ENFORCING")
+	PERMISSIVE = PolicyEnforcementModeP("PERMISSIVE")
+	DISABLED   = PolicyEnforcementModeP("DISABLED")
 )
 
 // Logic is an enum type for policy logic

--- a/utils.go
+++ b/utils.go
@@ -104,8 +104,13 @@ func DecisionStrategyP(value DecisionStrategy) *DecisionStrategy {
 	return &value
 }
 
-// LogicP returns a pointer for a LogicP value
+// LogicP returns a pointer for a Logic value
 func LogicP(value Logic) *Logic {
+	return &value
+}
+
+// PolicyEnforcementModeP returns a pointer for a PolicyEnforcementMode value
+func PolicyEnforcementModeP(value PolicyEnforcementMode) *PolicyEnforcementMode {
 	return &value
 }
 


### PR DESCRIPTION
Get error to convert json to *gocloak.Client{}

```json
[
  {
    "clientId": "test",
    "name": "test",
    "authorizationSettings": {
      "allowRemoteResourceManagement": true,
      "policyEnforcementMode": "ENFORCING",
      "decisionStrategy": "UNANIMOUS"
    }
  }
]
```

```golang
clients := &[]*gocloak.Client{}

err := json.Unmarshal(clientsJSON, clients)
```

```text
 json: cannot unmarshal string into Go struct field ResourceServerRepresentation.authorizationSettings.policyEnforcementMode of type gocloak.PolicyEnforcementMode
```

the type of enum **PolicyEnforcementMode** must change to **string**

It should same as enum **Logic** and **DecisionStrategy**

