### PR TITLE
defaults for P* utils

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -30,6 +30,9 @@ func BoolP(value bool) *bool {
 
 // PBool returns a boolean value from a pointer
 func PBool(value *bool) bool {
+	if value == nil {
+		return false
+	}
 	return *value
 }
 
@@ -50,16 +53,25 @@ func Int64P(value int64) *int64 {
 
 // PInt returns an integer value from a pointer
 func PInt(value *int) int {
+	if value == nil {
+		return 0
+	}
 	return *value
 }
 
 // PInt32 returns an int32 value from a pointer
 func PInt32(value *int32) int32 {
+	if value == nil {
+		return 0
+	}
 	return *value
 }
 
 // PInt64 returns an int64 value from a pointer
 func PInt64(value *int64) int64 {
+	if value == nil {
+		return 0
+	}
 	return *value
 }
 
@@ -75,11 +87,17 @@ func Float64P(value float64) *float64 {
 
 // PFloat32 returns an flaot32 value from a pointer
 func PFloat32(value *float32) float32 {
+	if value == nil {
+		return 0
+	}
 	return *value
 }
 
 // PFloat64 returns an flaot64 value from a pointer
 func PFloat64(value *float64) float64 {
+	if value == nil {
+		return 0
+	}
 	return *value
 }
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -42,6 +42,9 @@ func TestPBool(t *testing.T) {
 	p = false
 	v = gocloak.PBool(&p)
 	assert.False(t, v)
+
+	v = gocloak.PBool(nil)
+	assert.False(t, v)
 }
 
 func TestIntP(t *testing.T) {
@@ -66,6 +69,10 @@ func TestPInt(t *testing.T) {
 	v := gocloak.PInt(&p)
 	assert.Equal(t, p, v)
 	assert.IsType(t, p, v)
+
+	v = gocloak.PInt(nil)
+	assert.Equal(t, int(0), v)
+	assert.IsType(t, int(0), v)
 }
 
 func TestPInt32(t *testing.T) {
@@ -73,6 +80,10 @@ func TestPInt32(t *testing.T) {
 	v := gocloak.PInt32(&p)
 	assert.Equal(t, p, v)
 	assert.IsType(t, p, v)
+
+	v = gocloak.PInt32(nil)
+	assert.Equal(t, int32(0), v)
+	assert.IsType(t, int32(0), v)
 }
 
 func TestPInt64(t *testing.T) {
@@ -80,6 +91,10 @@ func TestPInt64(t *testing.T) {
 	v := gocloak.PInt64(&p)
 	assert.Equal(t, p, v)
 	assert.IsType(t, p, v)
+
+	v = gocloak.PInt64(nil)
+	assert.Equal(t, int64(0), v)
+	assert.IsType(t, int64(0), v)
 }
 
 func TestFloat32P(t *testing.T) {
@@ -98,12 +113,20 @@ func TestPFloat32(t *testing.T) {
 	v := gocloak.PFloat32(&p)
 	assert.Equal(t, p, v)
 	assert.IsType(t, p, v)
+
+	v = gocloak.PFloat32(nil)
+	assert.Equal(t, float32(0), v)
+	assert.IsType(t, float32(0), v)
 }
 func TestPFloat64(t *testing.T) {
 	p := 42.42
 	v := gocloak.PFloat64(&p)
 	assert.Equal(t, p, v)
 	assert.IsType(t, p, v)
+
+	v = gocloak.PFloat64(nil)
+	assert.Equal(t, float64(0), v)
+	assert.IsType(t, float64(0), v)
 }
 func TestNilOrEmptyArray(t *testing.T) {
 	a := gocloak.NilOrEmptyArray(&[]string{"c", "d"})


### PR DESCRIPTION
Default values for bool, ints and floats if provided pointer is nil in `P*` util functions