### PR TITLE
fix naming for authentication executions

### DIFF
--- a/models.go
+++ b/models.go
@@ -799,15 +799,19 @@ type CreateAuthenticationExecutionRepresentation struct {
 
 // ModifyAuthenticationExecutionRepresentation is the payload for updating an execution representation
 type ModifyAuthenticationExecutionRepresentation struct {
-	ID                  *string `json:"id,omitempty"`
-	Provider            *string `json:"providerId,omitempty"`
-	AuthenticatorConfig *string `json:"authenticatorConfig,omitempty"`
-	AuthenticatorFlow   *bool   `json:"authenticatorFlow,omitempty"`
-	AutheticatorFlow    *bool   `json:"autheticatorFlow,omitempty"`
-	FlowAlias           *string `json:"flowAlias,omitempty"`
-	Priority            *int    `json:"priority,omitempty"`
-	Requirement         *string `json:"requirement,omitempty"`
-	UserSetupAllowed    *bool   `json:"userSetupAllowed,omitempty"`
+	ID                   *string   `json:"id,omitempty"`
+	ProviderID           *string   `json:"providerId,omitempty"`
+	AuthenticationConfig *string   `json:"authenticationConfig,omitempty"`
+	AuthenticationFlow   *bool     `json:"authenticationFlow,omitempty"`
+	Requirement          *string   `json:"requirement,omitempty"`
+	FlowID               *string   `json:"flowId"`
+	DisplayName          *string   `json:"displayName,omitempty"`
+	Alias                *string   `json:"alias,omitempty"`
+	RequirementChoices   *[]string `json:"requirementChoices,omitempty"`
+	Configurable         *bool     `json:"configurable,omitempty"`
+	Level                *int      `json:"level,omitempty"`
+	Index                *int      `json:"index,omitempty"`
+	Description          *string   `json:"description"`
 }
 
 // MultiValuedHashMap represents something


### PR DESCRIPTION
Hey,

turns out #318 had some typos/renames (`authenticator` vs. `authentication`).
I'm sorry for not having checked them.

This PR should fix it, tested with the latest Keycloak 15.

This is breaking (backwards incompatible). We could either do it or keep the fields as they are, just fixing the json tags.
@Nerzal what do you think?