### PR TITLE
GetComponentsWithParams and UpdateComponent added

### DIFF
--- a/client.go
+++ b/client.go
@@ -1443,13 +1443,7 @@ func (client *gocloak) GetComponents(ctx context.Context, token, realm string) (
 func (client *gocloak) GetComponentsWithParams(ctx context.Context, token, realm string, params GetComponentsParams) ([]*Component, error) {
 	const errMessage = "could not get components"
 	var result []*Component
-	var componentURL string
 
-	if *params.ID != "" {
-		componentURL = fmt.Sprintf("components/%s", *params.ID)
-	} else {
-		componentURL = "components"
-	}
 	queryParams, err := GetQueryParams(params)
 	if err != nil {
 		return nil, errors.Wrap(err, errMessage)
@@ -1457,13 +1451,35 @@ func (client *gocloak) GetComponentsWithParams(ctx context.Context, token, realm
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
 		SetQueryParams(queryParams).
-		Get(client.getAdminRealmURL(realm, componentURL))
+		Get(client.getAdminRealmURL(realm, "components"))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err
 	}
 
 	return result, nil
+}
+
+// GetComponent get exactly one component by ID
+func (client *gocloak) GetComponent(ctx context.Context, token, realm string, componentID string) (*Component, error) {
+	const errMessage = "could not get components"
+	var result []*Component
+
+	componentURL := fmt.Sprintf("components/%s", componentID)
+
+	resp, err := client.getRequestWithBearerAuth(ctx, token).
+		SetResult(&result).
+		Get(client.getAdminRealmURL(realm, componentURL))
+
+	if err := checkForError(resp, err, errMessage); err != nil {
+		return nil, err
+	}
+
+	if len(result) != 1 {
+		return nil, fmt.Errorf("get %d components from keycloak by ID instead of one", len(result))
+	}
+
+	return result[0], nil
 }
 
 // UpdateComponent updates the given component

--- a/client.go
+++ b/client.go
@@ -1440,6 +1440,27 @@ func (client *gocloak) GetComponents(ctx context.Context, token, realm string) (
 	return result, nil
 }
 
+// GetComponentsWithParams get all components in realm with query params
+func (client *gocloak) GetComponentsWithParams(ctx context.Context, token, realm string, params GetComponentsParams) ([]*Component, error) {
+	const errMessage = "could not get components"
+
+	var result []*Component
+	queryParams, err := GetQueryParams(params)
+	if err != nil {
+		return nil, errors.Wrap(err, errMessage)
+	}
+	resp, err := client.getRequestWithBearerAuth(ctx, token).
+		SetResult(&result).
+		SetQueryParams(queryParams).
+		Get(client.getAdminRealmURL(realm, "components"))
+
+	if err := checkForError(resp, err, errMessage); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 // GetDefaultGroups returns a list of default groups
 func (client *gocloak) GetDefaultGroups(ctx context.Context, token, realm string) ([]*Group, error) {
 	const errMessage = "could not get default groups"

--- a/client.go
+++ b/client.go
@@ -1462,12 +1462,12 @@ func (client *gocloak) GetComponentsWithParams(ctx context.Context, token, realm
 }
 
 // UpdateComponent updates the given component
-func (client *gocloak) UpdateComponent(ctx context.Context, token, realm string, updatedComponent Component) error {
+func (client *gocloak) UpdateComponent(ctx context.Context, token, realm string, component Component) error {
 	const errMessage = "could not update component"
 
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
-		SetBody(updatedComponent).
-		Put(client.getAdminRealmURL(realm, "components", *updatedComponent.ID))
+		SetBody(component).
+		Put(client.getAdminRealmURL(realm, "components", PString(component.ID)))
 
 	return checkForError(resp, err, errMessage)
 }

--- a/client.go
+++ b/client.go
@@ -158,7 +158,6 @@ func injectTracingHeaders(ctx context.Context, req *resty.Request) *resty.Reques
 
 	// inject tracing header into request
 	err := tracer.Inject(span.Context(), opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(req.Header))
-
 	if err != nil {
 		return req
 	}
@@ -1443,8 +1442,14 @@ func (client *gocloak) GetComponents(ctx context.Context, token, realm string) (
 // GetComponentsWithParams get all components in realm with query params
 func (client *gocloak) GetComponentsWithParams(ctx context.Context, token, realm string, params GetComponentsParams) ([]*Component, error) {
 	const errMessage = "could not get components"
-
 	var result []*Component
+	var componentURL string
+
+	if *params.ID != "" {
+		componentURL = fmt.Sprintf("components/%s", *params.ID)
+	} else {
+		componentURL = "components"
+	}
 	queryParams, err := GetQueryParams(params)
 	if err != nil {
 		return nil, errors.Wrap(err, errMessage)
@@ -1452,7 +1457,7 @@ func (client *gocloak) GetComponentsWithParams(ctx context.Context, token, realm
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
 		SetQueryParams(queryParams).
-		Get(client.getAdminRealmURL(realm, "components"))
+		Get(client.getAdminRealmURL(realm, componentURL))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err
@@ -2228,7 +2233,7 @@ func (client *gocloak) ClearKeysCache(ctx context.Context, token, realm string) 
 	return checkForError(resp, err, errMessage)
 }
 
-//GetAuthenticationFlows get all authentication flows from a realm
+// GetAuthenticationFlows get all authentication flows from a realm
 func (client *gocloak) GetAuthenticationFlows(ctx context.Context, token, realm string) ([]*AuthenticationFlowRepresentation, error) {
 	const errMessage = "could not retrieve authentication flows"
 	var result []*AuthenticationFlowRepresentation
@@ -2242,7 +2247,7 @@ func (client *gocloak) GetAuthenticationFlows(ctx context.Context, token, realm 
 	return result, nil
 }
 
-//Create a new Authentication flow in a realm
+// Create a new Authentication flow in a realm
 func (client *gocloak) CreateAuthenticationFlow(ctx context.Context, token, realm string, flow AuthenticationFlowRepresentation) error {
 	const errMessage = "could not create authentication flows"
 	var result []*AuthenticationFlowRepresentation
@@ -2253,7 +2258,7 @@ func (client *gocloak) CreateAuthenticationFlow(ctx context.Context, token, real
 	return checkForError(resp, err, errMessage)
 }
 
-//DeleteAuthenticationFlow deletes a flow in a realm with the given ID
+// DeleteAuthenticationFlow deletes a flow in a realm with the given ID
 func (client *gocloak) DeleteAuthenticationFlow(ctx context.Context, token, realm, flowID string) error {
 	const errMessage = "could not delete authentication flows"
 	resp, err := client.getRequestWithBearerAuth(ctx, token).
@@ -2262,7 +2267,7 @@ func (client *gocloak) DeleteAuthenticationFlow(ctx context.Context, token, real
 	return checkForError(resp, err, errMessage)
 }
 
-//GetAuthenticationExecutions retrieves all executions of a given flow
+// GetAuthenticationExecutions retrieves all executions of a given flow
 func (client *gocloak) GetAuthenticationExecutions(ctx context.Context, token, realm, flow string) ([]*ModifyAuthenticationExecutionRepresentation, error) {
 	const errMessage = "could not retrieve authentication flows"
 	var result []*ModifyAuthenticationExecutionRepresentation
@@ -2276,7 +2281,7 @@ func (client *gocloak) GetAuthenticationExecutions(ctx context.Context, token, r
 	return result, nil
 }
 
-//CreateAuthenticationExecution creates a new execution for the given flow name in the given realm
+// CreateAuthenticationExecution creates a new execution for the given flow name in the given realm
 func (client *gocloak) CreateAuthenticationExecution(ctx context.Context, token, realm, flow string, execution CreateAuthenticationExecutionRepresentation) error {
 	const errMessage = "could not create authentication execution"
 	resp, err := client.getRequestWithBearerAuth(ctx, token).SetBody(execution).
@@ -2285,7 +2290,7 @@ func (client *gocloak) CreateAuthenticationExecution(ctx context.Context, token,
 	return checkForError(resp, err, errMessage)
 }
 
-//UpdateAuthenticationExecution updates an authentication execution for the given flow in the given realm
+// UpdateAuthenticationExecution updates an authentication execution for the given flow in the given realm
 func (client *gocloak) UpdateAuthenticationExecution(ctx context.Context, token, realm, flow string, execution ModifyAuthenticationExecutionRepresentation) error {
 	const errMessage = "could not update authentication execution"
 	resp, err := client.getRequestWithBearerAuth(ctx, token).SetBody(execution).
@@ -2303,7 +2308,7 @@ func (client *gocloak) DeleteAuthenticationExecution(ctx context.Context, token,
 	return checkForError(resp, err, errMessage)
 }
 
-//CreateAuthenticationExecutionFlow creates a new execution for the given flow name in the given realm
+// CreateAuthenticationExecutionFlow creates a new execution for the given flow name in the given realm
 func (client *gocloak) CreateAuthenticationExecutionFlow(ctx context.Context, token, realm, flow string, executionFlow CreateAuthenticationExecutionFlowRepresentation) error {
 	const errMessage = "could not create authentication execution flow"
 	resp, err := client.getRequestWithBearerAuth(ctx, token).SetBody(executionFlow).

--- a/client.go
+++ b/client.go
@@ -1463,7 +1463,7 @@ func (client *gocloak) GetComponentsWithParams(ctx context.Context, token, realm
 // GetComponent get exactly one component by ID
 func (client *gocloak) GetComponent(ctx context.Context, token, realm string, componentID string) (*Component, error) {
 	const errMessage = "could not get components"
-	var result []*Component
+	var result *Component
 
 	componentURL := fmt.Sprintf("components/%s", componentID)
 
@@ -1475,11 +1475,7 @@ func (client *gocloak) GetComponent(ctx context.Context, token, realm string, co
 		return nil, err
 	}
 
-	if len(result) != 1 {
-		return nil, fmt.Errorf("get %d components from keycloak by ID instead of one", len(result))
-	}
-
-	return result[0], nil
+	return result, nil
 }
 
 // UpdateComponent updates the given component

--- a/client.go
+++ b/client.go
@@ -1461,6 +1461,17 @@ func (client *gocloak) GetComponentsWithParams(ctx context.Context, token, realm
 	return result, nil
 }
 
+// UpdateComponent updates the given component
+func (client *gocloak) UpdateComponent(ctx context.Context, token, realm string, updatedComponent Component) error {
+	const errMessage = "could not update component"
+
+	resp, err := client.getRequestWithBearerAuth(ctx, token).
+		SetBody(updatedComponent).
+		Put(client.getAdminRealmURL(realm, "components", *updatedComponent.ID))
+
+	return checkForError(resp, err, errMessage)
+}
+
 // GetDefaultGroups returns a list of default groups
 func (client *gocloak) GetDefaultGroups(ctx context.Context, token, realm string) ([]*Group, error) {
 	const errMessage = "could not get default groups"

--- a/client_test.go
+++ b/client_test.go
@@ -6591,10 +6591,10 @@ func Test_UpdateComponent(t *testing.T) {
 	if len(components) != 1 {
 		require.NoError(t, fmt.Errorf("Expected 1 component, got %d", len(components)), "UpdateComponent failed")
 	}
-	if components[0].Name != component.Name {
+	if *components[0].Name != *component.Name {
 		require.NoError(
 			t,
-			fmt.Errorf("Expected name after update '%s', got %s", *component.Name, *components[0].Name),
+			fmt.Errorf("Expected name after update '%s', got '%s'", *component.Name, *components[0].Name),
 			"UpdateComponent failed",
 		)
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -6558,3 +6558,45 @@ func Test_GetComponentsWithParams(t *testing.T) {
 		require.NoError(t, fmt.Errorf("Expected 1 component, got %d", len(components)), "GetComponentsWithParams failed")
 	}
 }
+
+func Test_UpdateComponent(t *testing.T) {
+	// t.Parallel()
+	cfg := GetConfig(t)
+	client := NewClientWithDebug(t)
+	token := GetAdminToken(t, client)
+	tearDownComponent, _, component := CreateComponent(t, client, nil)
+	defer tearDownComponent()
+
+	component.Name = GetRandomNameP("UpdateComponent")
+
+	err := client.UpdateComponent(
+		context.Background(),
+		token.AccessToken,
+		cfg.GoCloak.Realm,
+		*component,
+	)
+	require.NoError(t, err, "UpdateComponent failed")
+
+	components, err := client.GetComponentsWithParams(
+		context.Background(),
+		token.AccessToken,
+		cfg.GoCloak.Realm,
+		gocloak.GetComponentsParams{
+			Name:         component.Name,
+			ProviderType: component.ProviderType,
+			ParentID:     component.ParentID,
+		},
+	)
+	require.NoError(t, err, "GetComponentWithParams after UpdateComponent failed")
+
+	if len(components) != 1 {
+		require.NoError(t, fmt.Errorf("Expected 1 component, got %d", len(components)), "UpdateComponent failed")
+	}
+	if components[0].Name != component.Name {
+		require.NoError(
+			t,
+			fmt.Errorf("Expected name after update '%s', got %s", *component.Name, *components[0].Name),
+			"UpdateComponent failed",
+		)
+	}
+}

--- a/client_test.go
+++ b/client_test.go
@@ -5279,7 +5279,6 @@ func Test_ErrorsGetAuthorizationPolicyScopes(t *testing.T) {
 				},
 			},
 		})
-
 	})
 
 	// Create SCOPE
@@ -6556,6 +6555,23 @@ func Test_GetComponentsWithParams(t *testing.T) {
 	if len(components) != 1 {
 		require.NoError(t, fmt.Errorf("Expected 1 component, got %d", len(components)), "GetComponentsWithParams failed")
 	}
+}
+
+func Test_GetComponent(t *testing.T) {
+	// t.Parallel()
+	cfg := GetConfig(t)
+	client := NewClientWithDebug(t)
+	token := GetAdminToken(t, client)
+	tearDownComponent, component := CreateComponent(t, client)
+	defer tearDownComponent()
+
+	_, err := client.GetComponent(
+		context.Background(),
+		token.AccessToken,
+		cfg.GoCloak.Realm,
+		*component.ID,
+	)
+	require.NoError(t, err, "GetComponent failed")
 }
 
 func Test_UpdateComponent(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -6507,13 +6507,11 @@ func TestGocloak_UpdateRequiredAction(t *testing.T) {
 	require.NoError(t, err, "Failed to update required action")
 }
 
-func CreateComponent(t *testing.T, client gocloak.GoCloak, newComponent *gocloak.Component) (func(), string, *gocloak.Component) {
-	if newComponent == nil {
-		newComponent = &gocloak.Component{
-			Name:         GetRandomNameP("CreateComponent"),
-			ProviderID:   gocloak.StringP("rsa-generated"),
-			ProviderType: gocloak.StringP("org.keycloak.keys.KeyProvider"),
-		}
+func CreateComponent(t *testing.T, client gocloak.GoCloak) (func(), *gocloak.Component) {
+	newComponent := &gocloak.Component{
+		Name:         GetRandomNameP("CreateComponent"),
+		ProviderID:   gocloak.StringP("rsa-generated"),
+		ProviderType: gocloak.StringP("org.keycloak.keys.KeyProvider"),
 	}
 	cfg := GetConfig(t)
 	token := GetAdminToken(t, client)
@@ -6532,7 +6530,8 @@ func CreateComponent(t *testing.T, client gocloak.GoCloak, newComponent *gocloak
 			createdID,
 		)
 	}
-	return tearDown, createdID, newComponent
+	newComponent.ID = &createdID
+	return tearDown, newComponent
 }
 
 func Test_GetComponentsWithParams(t *testing.T) {
@@ -6540,7 +6539,7 @@ func Test_GetComponentsWithParams(t *testing.T) {
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
-	tearDownComponent, _, component := CreateComponent(t, client, nil)
+	tearDownComponent, component := CreateComponent(t, client)
 	defer tearDownComponent()
 
 	components, err := client.GetComponentsWithParams(
@@ -6564,7 +6563,7 @@ func Test_UpdateComponent(t *testing.T) {
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
-	tearDownComponent, _, component := CreateComponent(t, client, nil)
+	tearDownComponent, component := CreateComponent(t, client)
 	defer tearDownComponent()
 
 	component.Name = GetRandomNameP("UpdateComponent")

--- a/client_test.go
+++ b/client_test.go
@@ -6507,7 +6507,7 @@ func TestGocloak_UpdateRequiredAction(t *testing.T) {
 	require.NoError(t, err, "Failed to update required action")
 }
 
-func CreateComponent(t *testing.T, client gocloak.GoCloak, newComponent *gocloak.Component) (func(), string) {
+func CreateComponent(t *testing.T, client gocloak.GoCloak, newComponent *gocloak.Component) (func(), string, *gocloak.Component) {
 	if newComponent == nil {
 		newComponent = &gocloak.Component{
 			Name:         GetRandomNameP("CreateComponent"),
@@ -6525,24 +6525,22 @@ func CreateComponent(t *testing.T, client gocloak.GoCloak, newComponent *gocloak
 	)
 	require.NoError(t, err, "CreateComponent failed")
 	tearDown := func() {
-		_ = client.DeleteClient(
+		_ = client.DeleteComponent(
 			context.Background(),
 			token.AccessToken,
 			cfg.GoCloak.Realm,
 			createdID,
 		)
 	}
-	return tearDown, createdID
+	return tearDown, createdID, newComponent
 }
 
 func Test_GetComponentsWithParams(t *testing.T) {
 	// t.Parallel()
-	var newComponent *gocloak.Component
-
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)
-	tearDownComponent, _ := CreateComponent(t, client, newComponent)
+	tearDownComponent, _, component := CreateComponent(t, client, nil)
 	defer tearDownComponent()
 
 	components, err := client.GetComponentsWithParams(
@@ -6550,9 +6548,9 @@ func Test_GetComponentsWithParams(t *testing.T) {
 		token.AccessToken,
 		cfg.GoCloak.Realm,
 		gocloak.GetComponentsParams{
-			Name:         newComponent.Name,
-			ProviderType: newComponent.ProviderType,
-			ParentID:     newComponent.ParentID,
+			Name:         component.Name,
+			ProviderType: component.ProviderType,
+			ParentID:     component.ParentID,
 		},
 	)
 	require.NoError(t, err, "GetComponentsWithParams failed")

--- a/gocloak.go
+++ b/gocloak.go
@@ -182,7 +182,7 @@ type GoCloak interface {
 	// GetComponentsWithParams get all components in realm with query params
 	GetComponentsWithParams(ctx context.Context, token, realm string, params GetComponentsParams) ([]*Component, error)
 	// UpdateComponent updates the given component
-	UpdateComponent(ctx context.Context, token, realm string, updatedComponent Component) error
+	UpdateComponent(ctx context.Context, token, realm string, component Component) error
 	// GetDefaultGroups returns a list of default groups
 	GetDefaultGroups(ctx context.Context, accessToken, realm string) ([]*Group, error)
 	// AddDefaultGroup adds group to the list of default groups

--- a/gocloak.go
+++ b/gocloak.go
@@ -181,6 +181,8 @@ type GoCloak interface {
 	GetComponents(ctx context.Context, accessToken, realm string) ([]*Component, error)
 	// GetComponentsWithParams get all components in realm with query params
 	GetComponentsWithParams(ctx context.Context, token, realm string, params GetComponentsParams) ([]*Component, error)
+	// UpdateComponent updates the given component
+	UpdateComponent(ctx context.Context, token, realm string, updatedComponent Component) error
 	// GetDefaultGroups returns a list of default groups
 	GetDefaultGroups(ctx context.Context, accessToken, realm string) ([]*Group, error)
 	// AddDefaultGroup adds group to the list of default groups

--- a/gocloak.go
+++ b/gocloak.go
@@ -181,6 +181,8 @@ type GoCloak interface {
 	GetComponents(ctx context.Context, accessToken, realm string) ([]*Component, error)
 	// GetComponentsWithParams get all components in realm with query params
 	GetComponentsWithParams(ctx context.Context, token, realm string, params GetComponentsParams) ([]*Component, error)
+	// GetComponent get exactly one component by ID
+	GetComponent(ctx context.Context, token, realm string, componentID string) (*Component, error)
 	// UpdateComponent updates the given component
 	UpdateComponent(ctx context.Context, token, realm string, component Component) error
 	// GetDefaultGroups returns a list of default groups

--- a/gocloak.go
+++ b/gocloak.go
@@ -179,6 +179,8 @@ type GoCloak interface {
 	GetKeyStoreConfig(ctx context.Context, accessToken, realm string) (*KeyStoreConfig, error)
 	// GetComponents gets components of the given realm
 	GetComponents(ctx context.Context, accessToken, realm string) ([]*Component, error)
+	// GetComponentsWithParams get all components in realm with query params
+	GetComponentsWithParams(ctx context.Context, token, realm string, params GetComponentsParams) ([]*Component, error)
 	// GetDefaultGroups returns a list of default groups
 	GetDefaultGroups(ctx context.Context, accessToken, realm string) ([]*Group, error)
 	// AddDefaultGroup adds group to the list of default groups
@@ -319,22 +321,22 @@ type GoCloak interface {
 	ClearUserCache(ctx context.Context, token, realm string) error
 	// ClearKeysCache clears realm cache
 	ClearKeysCache(ctx context.Context, token, realm string) error
-	//GetAuthenticationFlows get all authentication flows from a realm
+	// GetAuthenticationFlows get all authentication flows from a realm
 	GetAuthenticationFlows(ctx context.Context, token, realm string) ([]*AuthenticationFlowRepresentation, error)
-	//Create a new Authentication flow in a realm
+	// Create a new Authentication flow in a realm
 	CreateAuthenticationFlow(ctx context.Context, token, realm string, flow AuthenticationFlowRepresentation) error
-	//DeleteAuthenticationFlow deletes a flow in a realm with the given ID
+	// DeleteAuthenticationFlow deletes a flow in a realm with the given ID
 	DeleteAuthenticationFlow(ctx context.Context, token, realm, flowID string) error
-	//GetAuthenticationExecutions retrieves all executions of a given flow
+	// GetAuthenticationExecutions retrieves all executions of a given flow
 	GetAuthenticationExecutions(ctx context.Context, token, realm, flow string) ([]*ModifyAuthenticationExecutionRepresentation, error)
-	//CreateAuthenticationExecution creates a new execution for the given flow name in the given realm
+	// CreateAuthenticationExecution creates a new execution for the given flow name in the given realm
 	CreateAuthenticationExecution(ctx context.Context, token, realm, flow string, execution CreateAuthenticationExecutionRepresentation) error
-	//UpdateAuthenticationExecution updates an authentication execution for the given flow in the given realm
+	// UpdateAuthenticationExecution updates an authentication execution for the given flow in the given realm
 	UpdateAuthenticationExecution(ctx context.Context, token, realm, flow string, execution ModifyAuthenticationExecutionRepresentation) error
 	// DeleteAuthenticationExecution delete a single execution with the given ID
 	DeleteAuthenticationExecution(ctx context.Context, token, realm, executionID string) error
 
-	//CreateAuthenticationExecutionFlow creates a new flow execution for the given flow name in the given realm
+	// CreateAuthenticationExecutionFlow creates a new flow execution for the given flow name in the given realm
 	CreateAuthenticationExecutionFlow(ctx context.Context, token, realm, flow string, execution CreateAuthenticationExecutionFlowRepresentation) error
 
 	// *** Users ***

--- a/model_test.go
+++ b/model_test.go
@@ -167,7 +167,7 @@ func TestParseAPIErrType(t *testing.T) {
 }
 
 func TestStringer(t *testing.T) {
-	//nested structs
+	// nested structs
 	actions := []string{"someAction", "anotherAction"}
 	access := gocloak.AccessRepresentation{
 		Manage:      gocloak.BoolP(true),
@@ -247,7 +247,6 @@ func TestStringer(t *testing.T) {
 	"displayName": "someRealm"
 }`
 	assert.Equal(t, expectedStr, str)
-
 }
 
 type Stringable interface {
@@ -255,7 +254,6 @@ type Stringable interface {
 }
 
 func TestStringerOmitEmpty(t *testing.T) {
-
 	customs := []Stringable{
 		&gocloak.CertResponseKey{},
 		&gocloak.CertResponse{},
@@ -333,14 +331,13 @@ func TestStringerOmitEmpty(t *testing.T) {
 		&gocloak.GetResourcePoliciesParams{},
 		&gocloak.CredentialRepresentation{},
 		&gocloak.GetUsersParams{},
+		&gocloak.GetComponentsParams{},
 		&gocloak.GetClientsParams{},
 		&gocloak.RequestingPartyTokenOptions{},
 		&gocloak.RequestingPartyPermission{},
 	}
 
 	for _, custom := range customs {
-
 		assert.Equal(t, "{}", custom.(Stringable).String())
 	}
-
 }

--- a/models.go
+++ b/models.go
@@ -306,7 +306,6 @@ type GetComponentsParams struct {
 	Name         *string `json:"name,omitempty"`
 	ProviderType *string `json:"providerType,omitempty"`
 	ParentID     *string `json:"parentId,omitempty"`
-	ID           *string `json:"-"` // This is the path parameter.
 }
 
 // ExecuteActionsEmail represents parameters for executing action emails

--- a/models.go
+++ b/models.go
@@ -301,6 +301,13 @@ type GetUsersParams struct {
 	Username            *string `json:"username,omitempty"`
 }
 
+// GetComponentsParams represents the optional parameters for getting components
+type GetComponentsParams struct {
+	Name         *string `json:"name,omitempty"`
+	ProviderType *string `json:"providerType,omitempty"`
+	ParentID     *string `json:"parentId,omitempty"`
+}
+
 // ExecuteActionsEmail represents parameters for executing action emails
 type ExecuteActionsEmail struct {
 	UserID      *string   `json:"-"`
@@ -1321,7 +1328,6 @@ type RequiredActionProviderRepresentation struct {
 
 // prettyStringStruct returns struct formatted into pretty string
 func prettyStringStruct(t interface{}) string {
-
 	json, err := json.MarshalIndent(t, "", "\t")
 	if err != nil {
 		return ""
@@ -1348,6 +1354,7 @@ func (v *Attributes) String() string                                { return pre
 func (v *Access) String() string                                    { return prettyStringStruct(v) }
 func (v *UserGroup) String() string                                 { return prettyStringStruct(v) }
 func (v *GetUsersParams) String() string                            { return prettyStringStruct(v) }
+func (v *GetComponentsParams) String() string                       { return prettyStringStruct(v) }
 func (v *ExecuteActionsEmail) String() string                       { return prettyStringStruct(v) }
 func (v *Group) String() string                                     { return prettyStringStruct(v) }
 func (v *GroupsCount) String() string                               { return prettyStringStruct(v) }

--- a/models.go
+++ b/models.go
@@ -306,6 +306,7 @@ type GetComponentsParams struct {
 	Name         *string `json:"name,omitempty"`
 	ProviderType *string `json:"providerType,omitempty"`
 	ParentID     *string `json:"parentId,omitempty"`
+	ID           *string `json:"-"` // This is the path parameter.
 }
 
 // ExecuteActionsEmail represents parameters for executing action emails

--- a/models.go
+++ b/models.go
@@ -304,8 +304,8 @@ type GetUsersParams struct {
 // GetComponentsParams represents the optional parameters for getting components
 type GetComponentsParams struct {
 	Name         *string `json:"name,omitempty"`
-	ProviderType *string `json:"providerType,omitempty"`
-	ParentID     *string `json:"parentId,omitempty"`
+	ProviderType *string `json:"provider,omitempty"`
+	ParentID     *string `json:"parent,omitempty"`
 }
 
 // ExecuteActionsEmail represents parameters for executing action emails


### PR DESCRIPTION
Thanks for your contribution!

There is two new methods.
1. GetComponentsWithParams() . According to keycloak's documentation GET /{realm}/components has some query parameters. I create new function to compatibility with old versions, because changing of GetComponents s bad idea.
2 UpdateComponent - allow to update exists component.

All new methods covered by tests.
