### PR TITLE
add missing attributes to ProtocolMappersConfig

### DIFF
--- a/models.go
+++ b/models.go
@@ -429,6 +429,9 @@ type ProtocolMappersConfig struct {
 	UsermodelClientRoleMappingClientID *string `json:"usermodel.clientRoleMapping.clientId,omitempty"`
 	IncludedClientAudience             *string `json:"included.client.audience,omitempty"`
 	FullPath                           *string `json:"full.path,omitempty"`
+	AttributeName                      *string `json:"attribute.name,omitempty"`
+	AttributeNameFormat                *string `json:"attribute.nameformat,omitempty"`
+	Single                             *string `json:"single,omitempty"`
 }
 
 // Client is a ClientRepresentation


### PR DESCRIPTION
In my case I'm missing some attributes for the protocol mapper `role_list`

Actually when looking at the doc and keycloak code, `ProtocolMappersConfig` should be a `map[string]string`, I guess that would break things... This change fixes it for me, good enough for me :)