### PR TITLE
remove deprecated linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,6 @@ linters:
     - gofmt
     - misspell
     - gosec
-    - maligned
     - unconvert
     - revive
     - gocognit


### PR DESCRIPTION
Thanks for your contribution!
Hi, if there is an issue, that your PR adresses, please link it! 
------------------------------------------------------------------------------------
This PR aims to remove the deprecated linter "maligned". 

It was marked as deprecated in the [golangci-lint docs](https://golangci-lint.run/usage/linters/).