### PR TITLE
feat(Realm): get localizations

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -6265,7 +6265,7 @@ func Test_ImportIdentityProviderConfig(t *testing.T) {
 }
 
 func Test_ImportIdentityProviderConfigFromFile(t *testing.T) {
-	//// t.Parallel()
+	// t.Parallel()
 	cfg := GetConfig(t)
 	client := NewClientWithDebug(t)
 	token := GetAdminToken(t, client)

--- a/gocloak.go
+++ b/gocloak.go
@@ -319,22 +319,22 @@ type GoCloak interface {
 	ClearUserCache(ctx context.Context, token, realm string) error
 	// ClearKeysCache clears realm cache
 	ClearKeysCache(ctx context.Context, token, realm string) error
-	//GetAuthenticationFlows get all authentication flows from a realm
+	// GetAuthenticationFlows get all authentication flows from a realm
 	GetAuthenticationFlows(ctx context.Context, token, realm string) ([]*AuthenticationFlowRepresentation, error)
-	//Create a new Authentication flow in a realm
+	// Create a new Authentication flow in a realm
 	CreateAuthenticationFlow(ctx context.Context, token, realm string, flow AuthenticationFlowRepresentation) error
-	//DeleteAuthenticationFlow deletes a flow in a realm with the given ID
+	// DeleteAuthenticationFlow deletes a flow in a realm with the given ID
 	DeleteAuthenticationFlow(ctx context.Context, token, realm, flowID string) error
-	//GetAuthenticationExecutions retrieves all executions of a given flow
+	// GetAuthenticationExecutions retrieves all executions of a given flow
 	GetAuthenticationExecutions(ctx context.Context, token, realm, flow string) ([]*ModifyAuthenticationExecutionRepresentation, error)
-	//CreateAuthenticationExecution creates a new execution for the given flow name in the given realm
+	// CreateAuthenticationExecution creates a new execution for the given flow name in the given realm
 	CreateAuthenticationExecution(ctx context.Context, token, realm, flow string, execution CreateAuthenticationExecutionRepresentation) error
-	//UpdateAuthenticationExecution updates an authentication execution for the given flow in the given realm
+	// UpdateAuthenticationExecution updates an authentication execution for the given flow in the given realm
 	UpdateAuthenticationExecution(ctx context.Context, token, realm, flow string, execution ModifyAuthenticationExecutionRepresentation) error
 	// DeleteAuthenticationExecution delete a single execution with the given ID
 	DeleteAuthenticationExecution(ctx context.Context, token, realm, executionID string) error
 
-	//CreateAuthenticationExecutionFlow creates a new flow execution for the given flow name in the given realm
+	// CreateAuthenticationExecutionFlow creates a new flow execution for the given flow name in the given realm
 	CreateAuthenticationExecutionFlow(ctx context.Context, token, realm, flow string, execution CreateAuthenticationExecutionFlowRepresentation) error
 
 	// *** Users ***

--- a/model_test.go
+++ b/model_test.go
@@ -167,7 +167,7 @@ func TestParseAPIErrType(t *testing.T) {
 }
 
 func TestStringer(t *testing.T) {
-	//nested structs
+	// nested structs
 	actions := []string{"someAction", "anotherAction"}
 	access := gocloak.AccessRepresentation{
 		Manage:      gocloak.BoolP(true),

--- a/models.go
+++ b/models.go
@@ -1037,6 +1037,23 @@ type ServerInfoRepesentation struct {
 	PasswordPolicies       []*PasswordPolicy         `json:"passwordPolicies,omitempty"`
 	ProtocolMapperTypes    *ProtocolMapperTypes      `json:"protocolMapperTypes,omitempty"`
 	BuiltinProtocolMappers *BuiltinProtocolMappers   `json:"builtinProtocolMappers,omitempty"`
+	Themes                 *Themes                   `json:"themes,omitempty"`
+}
+
+// ThemeRepresentation contains the theme name and locales
+type ThemeRepresentation struct {
+	Name    string   `json:"name,omitempty"`
+	Locales []string `json:"locales,omitempty"`
+}
+
+// Themes contains the available keycloak themes with locales
+type Themes struct {
+	Accounts []ThemeRepresentation `json:"account,omitempty"`
+	Admin    []ThemeRepresentation `json:"admin,omitempty"`
+	Common   []ThemeRepresentation `json:"common,omitempty"`
+	Email    []ThemeRepresentation `json:"email,omitempty"`
+	Login    []ThemeRepresentation `json:"login,omitempty"`
+	Welcome  []ThemeRepresentation `json:"welcome,omitempty"`
 }
 
 // FederatedIdentityRepresentation represents an user federated identity


### PR DESCRIPTION
Hi,

this adds mappings for ServerInfo localizations. I think it is limited to the well-defined list (account, admin, etc...).
Otherwise we could make it a map instead?