### PR TITLE
fix(realm): error handling for update required action

### DIFF
--- a/client.go
+++ b/client.go
@@ -3816,11 +3816,11 @@ func (client *gocloak) UpdateRequiredAction(ctx context.Context, token string, r
 	if NilOrEmpty(requiredAction.ProviderID) {
 		return errors.New("providerId is required for updating a required action")
 	}
-	_, err := client.getRequestWithBearerAuth(ctx, token).
+	resp, err := client.getRequestWithBearerAuth(ctx, token).
 		SetBody(requiredAction).
 		Put(client.getAdminRealmURL(realm, "authentication", "required-actions", *requiredAction.ProviderID))
 
-	return err
+	return checkForError(resp, err, errMessage)
 }
 
 // DeleteRequiredAction updates a required action for a given realm


### PR DESCRIPTION
Hi @Nerzal,

This fixes the error handling for updating a required action if status is >399 