### PR TITLE
feat(gocloak): add GetCompositeRolesByRoleID

### DIFF
--- a/client.go
+++ b/client.go
@@ -2015,6 +2015,22 @@ func (client *gocloak) GetCompositeRealmRoles(ctx context.Context, token, realm,
 	return result, nil
 }
 
+// GetCompositeRolesByRoleID returns all realm composite roles associated with the given client role
+func (client *gocloak) GetCompositeRolesByRoleID(ctx context.Context, token, realm, roleID string) ([]*Role, error) {
+	const errMessage = "could not get composite client roles by role id"
+
+	var result []*Role
+	resp, err := client.getRequestWithBearerAuth(ctx, token).
+		SetResult(&result).
+		Get(client.getAdminRealmURL(realm, "roles-by-id", roleID, "composites"))
+
+	if err = checkForError(resp, err, errMessage); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 // GetCompositeRealmRolesByRoleID returns all realm composite roles associated with the given client role
 func (client *gocloak) GetCompositeRealmRolesByRoleID(ctx context.Context, token, realm, roleID string) ([]*Role, error) {
 	const errMessage = "could not get composite client roles by role id"

--- a/gocloak.go
+++ b/gocloak.go
@@ -250,6 +250,8 @@ type GoCloak interface {
 	DeleteRealmRoleComposite(ctx context.Context, token, realm, roleName string, roles []Role) error
 	// GetCompositeRealmRoles returns all realm composite roles associated with the given realm role
 	GetCompositeRealmRoles(ctx context.Context, token, realm, roleName string) ([]*Role, error)
+	// GetCompositeRolesByRoleID returns all realm composite roles associated with the given client role
+	GetCompositeRolesByRoleID(ctx context.Context, token, realm, roleID string) ([]*Role, error)
 	// GetCompositeRealmRolesByRoleID returns all realm composite roles associated with the given client role
 	GetCompositeRealmRolesByRoleID(ctx context.Context, token, realm, roleID string) ([]*Role, error)
 	// GetCompositeRealmRolesByUserID returns all realm roles and composite roles assigned to the given user


### PR DESCRIPTION
Currently only the subresources with /realm and /clients exist, but the composites endpoint with all composites (by role id) is missing.