### PR TITLE
fix(client): correct serverinfo endpoint

### DIFF
--- a/client.go
+++ b/client.go
@@ -267,13 +267,13 @@ func SetCertCacheInvalidationTime(duration time.Duration) func(g *GoCloak) {
 }
 
 // GetServerInfo fetches the server info.
-func (g *GoCloak) GetServerInfo(ctx context.Context, accessToken string) ([]*ServerInfoRepresentation, error) {
+func (g *GoCloak) GetServerInfo(ctx context.Context, accessToken string) (*ServerInfoRepresentation, error) {
 	errMessage := "could not get server info"
-	var result []*ServerInfoRepresentation
+	var result *ServerInfoRepresentation
 
 	resp, err := g.getRequestWithBearerAuth(ctx, accessToken).
 		SetResult(&result).
-		Get(makeURL(g.basePath, "admin", "realms"))
+		Get(makeURL(g.basePath, "admin", "serverinfo"))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err


### PR DESCRIPTION
Hi @Nerzal,

I assume the serverinfo broke with the latest update, it should be one `ServerInfoRepresentation` and the path should be `/serverinfo`, not `/realms`.

Let me know if I'm missing something here?


Best and thanks for all the work, Basti