### PR TITLE
add method to revoke token

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -6749,3 +6749,19 @@ func Test_UpdateComponent(t *testing.T) {
 		)
 	}
 }
+
+func Test_RevokeToken(t *testing.T) {
+	t.Parallel()
+	cfg := GetConfig(t)
+	client := NewClientWithDebug(t)
+	SetUpTestUser(t, client)
+	token := GetUserToken(t, client)
+	err := client.RevokeToken(
+		context.Background(),
+		cfg.GoCloak.Realm,
+		cfg.GoCloak.ClientID,
+		cfg.GoCloak.ClientSecret,
+		token.RefreshToken,
+	)
+	require.NoError(t, err, "Revoke failed")
+}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hardyrarso/gocloak/v12
+module github.com/Nerzal/gocloak/v12
 
 go 1.18
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Nerzal/gocloak/v12
+module github.com/hardyrarso/gocloak/v12
 
 go 1.18
 

--- a/models.go
+++ b/models.go
@@ -893,6 +893,28 @@ type MultiValuedHashMap struct {
 	Threshold  *int32   `json:"threshold,omitempty"`
 }
 
+// AuthorizationParameters represents the options to obtain get an authorization
+type AuthorizationParameters struct {
+	ResponseType *string `json:"code,omitempty"`
+	ClientID     *string `json:"client_id,omitempty"`
+	Scope        *string `json:"scope,omitempty"`
+	RedirectURI  *string `json:"redirect_uri,omitempty"`
+	State        *string `json:"state,omitempty"`
+	Nonce        *string `json:"nonce,omitempty"`
+	IDTokenHint  *string `json:"id_token_hint,omitempty"`
+}
+
+// FormData returns a map of options to be used in SetFormData function
+func (p *AuthorizationParameters) FormData() map[string]string {
+	m, _ := json.Marshal(p)
+	var res map[string]string
+	_ = json.Unmarshal(m, &res)
+	return res
+}
+
+type AuthorizationResponse struct {
+}
+
 // TokenOptions represents the options to obtain a token
 type TokenOptions struct {
 	ClientID            *string   `json:"client_id,omitempty"`


### PR DESCRIPTION
Add a method to send a request to the `/openid-connect/revoke` endpoint

Let me know if I need to change anything! Thank you for maintaining gocloak.