### PR TITLE
Fix openid scope

### DIFF
--- a/client.go
+++ b/client.go
@@ -593,6 +593,7 @@ func (g *GoCloak) Login(ctx context.Context, clientID, clientSecret, realm, user
 		GrantType:    StringP("password"),
 		Username:     &username,
 		Password:     &password,
+		Scope:        StringP("openid"),
 	})
 }
 


### PR DESCRIPTION
Hi,

this should fix the erroring unit tests.
It adds the missing `openid` scope, which is now required by Keycloak.


Best regards and a happy new year,
Bastian