### PR TITLE
Fix token introspection example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ go get github.com/Nerzal/gocloak/v13
   panic("Inspection failed:"+ err.Error())
  }
 
- if !rptResult.Active {
+ if !*rptResult.Active {
   panic("Token is not active")
  }
 


### PR DESCRIPTION
This fix was [previously submitted](https://github.com/Nerzal/gocloak/pull/271) by @joelhy but seems to have gotten reverted somehow.

`if !rptResult.Active` produces a build error: `invalid operation: operator ! not defined on rptResult.Active (variable of type *bool)`

Should be: `if !*rptResult.Active`