### PR TITLE
Add missing fields to GetGroupsParams struct

### DIFF
--- a/models.go
+++ b/models.go
@@ -342,11 +342,13 @@ type GroupsCount struct {
 
 // GetGroupsParams represents the optional parameters for getting groups
 type GetGroupsParams struct {
-	First               *int    `json:"first,string,omitempty"`
-	Max                 *int    `json:"max,string,omitempty"`
-	Search              *string `json:"search,omitempty"`
-	Full                *bool   `json:"full,string,omitempty"`
 	BriefRepresentation *bool   `json:"briefRepresentation,string,omitempty"`
+	Exact               *bool   `json:"exact,string,omitempty"`
+	First               *int    `json:"first,string,omitempty"`
+	Full                *bool   `json:"full,string,omitempty"`
+	Max                 *int    `json:"max,string,omitempty"`
+	Q                   *string `json:"q,omitempty"`
+	Search              *string `json:"search,omitempty"`
 }
 
 // MarshalJSON is a custom json marshaling function to automatically set the Full and BriefRepresentation properties


### PR DESCRIPTION
Adds the `Exact` and `Q` fields to the `GetGroupsParams` struct, to match the [API docs](https://www.keycloak.org/docs-api/21.0.2/rest-api/index.html#_groups_resource). I've also re-ordered the fields in alphabetical order.

The `Full` field looks like it might be old, as that parameter doesn't exist in the docs. I can remove that as well but wanted to confirm first.