### PR TITLE
feat: add support for resource server settings endpoint

### DIFF
--- a/client.go
+++ b/client.go
@@ -3157,13 +3157,13 @@ func (g *GoCloak) GetResourcesClient(ctx context.Context, token, realm string, p
 // GetResourceServer returns resource server settings.
 // The access token must have the realm view_clients role on its service
 // account to be allowed to call this endpoint.
-func (g *GoCloak) GetResourceServer(ctx context.Context, token, realm string) (*ResourceServerRepresentation, error) {
+func (g *GoCloak) GetResourceServer(ctx context.Context, token, realm, idOfClient string) (*ResourceServerRepresentation, error) {
 	const errMessage = "could not get resource server settings"
 
 	var result *ResourceServerRepresentation
 	resp, err := g.GetRequestWithBearerAuth(ctx, token).
 		SetResult(&result).
-		Get(g.getAdminRealmURL(realm, "authz", "resource-server", "settings"))
+		Get(g.getAdminRealmURL(realm, "clients", idOfClient, "authz", "resource-server", "settings"))
 
 	if err := checkForError(resp, err, errMessage); err != nil {
 		return nil, err

--- a/client.go
+++ b/client.go
@@ -3154,6 +3154,24 @@ func (g *GoCloak) GetResourcesClient(ctx context.Context, token, realm string, p
 	return result, nil
 }
 
+// GetResourceServer returns resource server settings.
+// The access token must have the realm view_clients role on its service
+// account to be allowed to call this endpoint.
+func (g *GoCloak) GetResourceServer(ctx context.Context, token, realm string) (*ResourceServerRepresentation, error) {
+	const errMessage = "could not get resource server settings"
+
+	var result *ResourceServerRepresentation
+	resp, err := g.GetRequestWithBearerAuth(ctx, token).
+		SetResult(&result).
+		Get(g.getAdminRealmURL(realm, "authz", "resource-server", "settings"))
+
+	if err := checkForError(resp, err, errMessage); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 // UpdateResource updates a resource associated with the client, using access token from admin
 func (g *GoCloak) UpdateResource(ctx context.Context, token, realm, idOfClient string, resource ResourceRepresentation) error {
 	const errMessage = "could not update resource"

--- a/client_test.go
+++ b/client_test.go
@@ -4986,6 +4986,23 @@ func Test_CreateListGetUpdateDeleteResourceClient(t *testing.T) {
 	require.Equal(t, *(createdResource.Name), *(updatedResource.Name))
 }
 
+func Test_GetResourceServer(t *testing.T) {
+	t.Parallel()
+	cfg := GetConfig(t)
+	client := NewClientWithDebug(t)
+	token := GetAdminToken(t, client)
+
+	rs, err := client.GetResourceServer(
+		context.Background(),
+		token.AccessToken,
+		cfg.GoCloak.Realm,
+		gocloakClientID,
+	)
+	require.NoError(t, err, "GetResourceServer failed")
+	require.NotNil(t, rs)
+	t.Logf("Resource server settings: %+v", rs)
+}
+
 func Test_CreateListGetUpdateDeleteResource(t *testing.T) {
 	t.Parallel()
 	cfg := GetConfig(t)


### PR DESCRIPTION
## Goal of this PR

Fixes #420 

## How to test it

I believe the unit test should work? I wasn't able to make the tests run properly on my machine, since I assume they require a clean local keycloak install to function. Since there seems to be a CI, I will debug them using the CI if that's OK.