### PR TITLE
Allow scripts to be setup for script protocol mappers

### DIFF
--- a/models.go
+++ b/models.go
@@ -447,6 +447,7 @@ type ProtocolMappersConfig struct {
 	AttributeName                      *string `json:"attribute.name,omitempty"`
 	AttributeNameFormat                *string `json:"attribute.nameformat,omitempty"`
 	Single                             *string `json:"single,omitempty"`
+	Script                             *string `json:"script,omitempty"`
 }
 
 // Client is a ClientRepresentation


### PR DESCRIPTION
Hey there,

had the need to create script based protocol mappers and noticed that the corresponding field is missing in the ProtocolMappersConfig struct.

I'm not really deep into the scripting side of keycloak, therefore i'm not sure what a possible/good test case would be.