### PR TITLE
Implement method to get group's child groups using Keycloak 23 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ type GoCloak interface {
  GetGroups(ctx context.Context, accessToken, realm string, params GetGroupsParams) ([]*Group, error)
  GetGroupsCount(ctx context.Context, token, realm string, params GetGroupsParams) (int, error)
  GetGroup(ctx context.Context, accessToken, realm, groupID string) (*Group, error)
+ GetChildGroups(ctx context.Context, token, realm, groupID string) ([]*Group, error)
  GetDefaultGroups(ctx context.Context, accessToken, realm string) ([]*Group, error)
  AddDefaultGroup(ctx context.Context, accessToken, realm, groupID string) error
  RemoveDefaultGroup(ctx context.Context, accessToken, realm, groupID string) error

--- a/client.go
+++ b/client.go
@@ -1740,6 +1740,23 @@ func (g *GoCloak) GetGroups(ctx context.Context, token, realm string, params Get
 	return result, nil
 }
 
+// GetChildGroups get child groups of group with id in realm
+func (g *GoCloak) GetChildGroups(ctx context.Context, token, realm, groupID string) ([]*Group, error) {
+	const errMessage = "could not get child groups"
+
+	var result []*Group
+
+	resp, err := g.GetRequestWithBearerAuth(ctx, token).
+		SetResult(&result).
+		Get(g.getAdminRealmURL(realm, "groups", groupID, "children"))
+
+	if err := checkForError(resp, err, errMessage); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
 // GetGroupManagementPermissions returns whether group Authorization permissions have been initialized or not and a reference
 // to the managed permissions
 func (g *GoCloak) GetGroupManagementPermissions(ctx context.Context, token, realm string, idOfGroup string) (*ManagementPermissionRepresentation, error) {

--- a/client_test.go
+++ b/client_test.go
@@ -2458,6 +2458,39 @@ func Test_GetGroupMembers(t *testing.T) {
 	require.Len(t, users, 1)
 }
 
+func Test_GetChildGroups(t *testing.T) {
+	t.Parallel()
+	cfg := GetConfig(t)
+	client := NewClientWithDebug(t)
+	token := GetAdminToken(t, client)
+
+	tearDown, parentGroupID := CreateGroup(t, client)
+	defer tearDown()
+
+	childGroupIDs := make([]string, 0)
+	for i := 0; i < 2; i++ {
+		id, err := client.CreateChildGroup(
+			context.Background(),
+			token.AccessToken,
+			cfg.GoCloak.Realm,
+			parentGroupID,
+			gocloak.Group{
+				Name: GetRandomNameP("GroupName"),
+			},
+		)
+		require.NoError(t, err, "CreateChildGroup failed")
+		childGroupIDs = append(childGroupIDs, id)
+	}
+
+	res, err := client.GetChildGroups(
+		context.Background(),
+		token.AccessToken,
+		cfg.GoCloak.Realm,
+		parentGroupID)
+	require.NoError(t, err, "GetChildGroups failed")
+	require.Len(t, res, len(childGroupIDs))
+}
+
 func Test_ListAddRemoveDefaultGroups(t *testing.T) {
 	t.Parallel()
 	cfg := GetConfig(t)


### PR DESCRIPTION


This doesn't resolve the issue https://github.com/Nerzal/gocloak/issues/456 with `GetGroups` and `GetGroup` not including the child/sub groups in the results - because of changes in Keycloak 23's API: https://www.keycloak.org/docs/latest/release_notes/index.html#group-scalability

Rather, this uses the `GET /admin/realms/{realm}/groups/{id}/children` endpoint in Keycloak 23's API to get a group's child groups - as mentioned in https://github.com/Nerzal/gocloak/issues/456#issuecomment-1874185851

Method was tested locally with `quay.io/keycloak/keycloak:23.0.4` image.

As mentioned in https://github.com/Nerzal/gocloak/issues/456#issuecomment-1908854180, this method could be expanded with a `params GetChildGroupsParams` parameter.