### PR TITLE
fix: add Type field to ClientScope model

### DIFF
--- a/models.go
+++ b/models.go
@@ -408,6 +408,7 @@ type MappingsRepresentation struct {
 type ClientScope struct {
 	ID                    *string                `json:"id,omitempty"`
 	Name                  *string                `json:"name,omitempty"`
+	Type                  *string                `json:"type,omitempty"`
 	Description           *string                `json:"description,omitempty"`
 	Protocol              *string                `json:"protocol,omitempty"`
 	ClientScopeAttributes *ClientScopeAttributes `json:"attributes,omitempty"`


### PR DESCRIPTION
It's currently impossible to create default scopes since the Type parameter is missing.

This PR adds a Type field to the Client Scope model.