### PR TITLE
Error appropriate for edge case

### DIFF
--- a/client.go
+++ b/client.go
@@ -2368,7 +2368,9 @@ func (g *GoCloak) GetAvailableRealmRolesByGroupID(ctx context.Context, token, re
 // GetRealm returns top-level representation of the realm
 func (g *GoCloak) GetRealm(ctx context.Context, token, realm string) (*RealmRepresentation, error) {
 	const errMessage = "could not get realm"
-
+	if realm == "" {
+		return nil, errors.New("realm is empty")
+	}
 	var result RealmRepresentation
 	resp, err := g.GetRequestWithBearerAuth(ctx, token).
 		SetResult(&result).


### PR DESCRIPTION
This fixes #470, I feel that a specific error for an empty string is warranted due to it being a valid parameter for the API call which results in an error that is not standard in gocloak, which is the deserialization error of an array.
```bash
d@n:~/code/gocloak$ ./run-tests.sh
WARN[0000] /home/d/code/gocloak/docker-compose.yml: `version` is obsolete 
WARN[0000] /home/d/code/gocloak/docker-compose.yml: `version` is obsolete 
[+] Running 2/2
 ✔ Network gocloak_default       Created                                                                                                                                                                                                                 0.1s 
 ✔ Container gocloak-keycloak-1  Started                                                                                                                                                                                                                 0.1s 
Checking service availability at http://localhost:8080/health (CTRL+C to exit)
Service is now available at http://localhost:8080
goos: linux
goarch: amd64
pkg: github.com/Nerzal/gocloak/v13
cpu: AMD Ryzen 9 7950X3D 16-Core Processor          
BenchmarkLogin                        39          28687588 ns/op           91675 B/op        221 allocs/op
BenchmarkLogin-2                      38          28366240 ns/op           90664 B/op        221 allocs/op
BenchmarkLoginParallel                38          28478975 ns/op           76846 B/op        221 allocs/op
BenchmarkLoginParallel-2              81          14708498 ns/op           82870 B/op        221 allocs/op
BenchmarkGetGroups                  2126            503609 ns/op           35980 B/op         97 allocs/op
BenchmarkGetGroups-2                2113            488856 ns/op           37906 B/op         97 allocs/op
BenchmarkGetGroupsFull              2592            437149 ns/op           37797 B/op        116 allocs/op
BenchmarkGetGroupsFull-2            2640            431464 ns/op           37439 B/op        116 allocs/op
BenchmarkGetGroupsBrief             2770            423735 ns/op           38478 B/op        116 allocs/op
BenchmarkGetGroupsBrief-2           2434            456469 ns/op           37064 B/op        116 allocs/op
BenchmarkGetGroup                   2175            489783 ns/op           37590 B/op        130 allocs/op
BenchmarkGetGroup-2                 2212            529947 ns/op           36733 B/op        130 allocs/op
BenchmarkGetGroupByPath             2754            404113 ns/op           37358 B/op        120 allocs/op
BenchmarkGetGroupByPath-2           2394            446270 ns/op           36290 B/op        120 allocs/op
PASS
coverage: 81.9% of statements
ok      github.com/Nerzal/gocloak/v13   35.480s
```