### PR TITLE
Change GetComponentsParams "ProviderType" from "provider" to "type"

### DIFF
--- a/models.go
+++ b/models.go
@@ -305,7 +305,7 @@ type GetUsersParams struct {
 // GetComponentsParams represents the optional parameters for getting components
 type GetComponentsParams struct {
 	Name         *string `json:"name,omitempty"`
-	ProviderType *string `json:"provider,omitempty"`
+	ProviderType *string `json:"type,omitempty"`
 	ParentID     *string `json:"parent,omitempty"`
 }
 


### PR DESCRIPTION
This PR is to correct the issue https://github.com/Nerzal/gocloak/issues/492 i've changed GetComponentsParams ProviderType from "provider" to "type".

cf: https://www.keycloak.org/docs-api/latest/rest-api/index.html#_component
![image](https://github.com/user-attachments/assets/7e8b6fd8-2602-4e5c-8ec8-f79dcf58f395)

i've not changed the attrribute name "ProviderType"  just the params name ("type" in place of "provider") to avoid changing the rest of the code.

https://github.com/Nerzal/gocloak/blob/77d3ec8168e7c3b1fc9a3554d739b7ea73af1f63/models.go#L305-L310