### PR TITLE
fix: golangci-lint warnings and tests

### DIFF
--- a/client.go
+++ b/client.go
@@ -12,14 +12,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Nerzal/gocloak/v13/pkg/jwx"
 	"github.com/go-resty/resty/v2"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/segmentio/ksuid"
 	"golang.org/x/mod/semver"
-
-	"github.com/Nerzal/gocloak/v13/pkg/jwx"
 )
 
 // GoCloak provides functionalities to talk to Keycloak.

--- a/client.go
+++ b/client.go
@@ -12,14 +12,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/Nerzal/gocloak/v13/pkg/jwx"
 	"github.com/go-resty/resty/v2"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/segmentio/ksuid"
 	"golang.org/x/mod/semver"
-
-	"github.com/Nerzal/gocloak/v13/pkg/jwx"
 )
 
 // GoCloak provides functionalities to talk to Keycloak.
@@ -64,14 +63,9 @@ func makeURL(path ...string) string {
 //
 // 1 if the provided version is higher than the server version
 func (g *GoCloak) compareVersions(ctx context.Context, v, token string) (int, error) {
-	curVersion := g.Config.version
-	if curVersion == "" {
-		curV, err := g.getServerVersion(ctx, token)
-		if err != nil {
-			return 0, err
-		}
-
-		curVersion = curV
+	curVersion, err := g.getServerVersion(ctx, token)
+	if err != nil {
+		return 0, err
 	}
 
 	curVersion = "v" + curVersion
@@ -3626,6 +3620,7 @@ func (g *GoCloak) CreatePolicy(ctx context.Context, token, realm, idOfClient str
 	if err != nil {
 		return nil, err
 	}
+
 	shouldAddType := compResult != 1
 
 	path := []string{"clients", idOfClient, "authz", "resource-server", "policy"}

--- a/client.go
+++ b/client.go
@@ -12,13 +12,14 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Nerzal/gocloak/v13/pkg/jwx"
 	"github.com/go-resty/resty/v2"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pkg/errors"
 	"github.com/segmentio/ksuid"
 	"golang.org/x/mod/semver"
+
+	"github.com/Nerzal/gocloak/v13/pkg/jwx"
 )
 
 // GoCloak provides functionalities to talk to Keycloak.

--- a/client.go
+++ b/client.go
@@ -63,7 +63,7 @@ func makeURL(path ...string) string {
 // 0 if the provided version is equal to the server version
 //
 // 1 if the provided version is higher than the server version
-func (g *GoCloak) compareVersions(v, token string, ctx context.Context) (int, error) {
+func (g *GoCloak) compareVersions(ctx context.Context, v, token string) (int, error) {
 	curVersion := g.Config.version
 	if curVersion == "" {
 		curV, err := g.getServerVersion(ctx, token)
@@ -74,7 +74,7 @@ func (g *GoCloak) compareVersions(v, token string, ctx context.Context) (int, er
 		curVersion = curV
 	}
 
-	curVersion = "v" + g.Config.version
+	curVersion = "v" + curVersion
 	if v[0] != 'v' {
 		v = "v" + v
 	}
@@ -145,7 +145,7 @@ func (g *GoCloak) GetRequestWithBasicAuth(ctx context.Context, clientID, clientS
 	return req
 }
 
-func (g *GoCloak) getRequestingParty(ctx context.Context, token string, realm string, options RequestingPartyTokenOptions, res interface{}) (*resty.Response, error) {
+func (g *GoCloak) getRequestingParty(ctx context.Context, token, realm string, options RequestingPartyTokenOptions, res any) (*resty.Response, error) {
 	return g.GetRequestWithBearerAuth(ctx, token).
 		SetFormData(options.FormData()).
 		SetFormDataFromValues(url.Values{"permission": PStringSlice(options.Permissions)}).
@@ -275,7 +275,7 @@ func (g *GoCloak) getAdminRealmURL(realm string, path ...string) string {
 	return makeURL(path...)
 }
 
-func (g *GoCloak) getAttackDetectionURL(realm string, user string, path ...string) string {
+func (g *GoCloak) getAttackDetectionURL(realm, user string, path ...string) string {
 	path = append([]string{g.basePath, g.Config.authAdminRealms, realm, g.Config.attackDetection, user}, path...)
 	return makeURL(path...)
 }
@@ -372,10 +372,10 @@ func (g *GoCloak) GetUserInfo(ctx context.Context, accessToken, realm string) (*
 }
 
 // GetRawUserInfo calls the UserInfo endpoint and returns a raw json object
-func (g *GoCloak) GetRawUserInfo(ctx context.Context, accessToken, realm string) (map[string]interface{}, error) {
+func (g *GoCloak) GetRawUserInfo(ctx context.Context, accessToken, realm string) (map[string]any, error) {
 	const errMessage = "could not get user info"
 
-	var result map[string]interface{}
+	var result map[string]any
 	resp, err := g.GetRequestWithBearerAuth(ctx, accessToken).
 		SetResult(&result).
 		Get(g.getRealmURL(realm, g.Config.openIDConnect, "userinfo"))
@@ -650,7 +650,7 @@ func (g *GoCloak) LoginClientSignedJWT(
 	ctx context.Context,
 	clientID,
 	realm string,
-	key interface{},
+	key any,
 	signedMethod jwt.SigningMethod,
 	expiresAt *jwt.NumericDate,
 ) (*JWT, error) {
@@ -934,7 +934,7 @@ func (g *GoCloak) UpdateGroup(ctx context.Context, token, realm string, updatedG
 }
 
 // UpdateGroupManagementPermissions updates the given group management permissions
-func (g *GoCloak) UpdateGroupManagementPermissions(ctx context.Context, accessToken, realm string, idOfGroup string, managementPermissions ManagementPermissionRepresentation) (*ManagementPermissionRepresentation, error) {
+func (g *GoCloak) UpdateGroupManagementPermissions(ctx context.Context, accessToken, realm, idOfGroup string, managementPermissions ManagementPermissionRepresentation) (*ManagementPermissionRepresentation, error) {
 	const errMessage = "could not update group management permissions"
 
 	var result ManagementPermissionRepresentation
@@ -989,7 +989,7 @@ func (g *GoCloak) UpdateClientRepresentation(ctx context.Context, accessToken, r
 }
 
 // UpdateClientManagementPermissions updates the given client management permissions
-func (g *GoCloak) UpdateClientManagementPermissions(ctx context.Context, accessToken, realm string, idOfClient string, managementPermissions ManagementPermissionRepresentation) (*ManagementPermissionRepresentation, error) {
+func (g *GoCloak) UpdateClientManagementPermissions(ctx context.Context, accessToken, realm, idOfClient string, managementPermissions ManagementPermissionRepresentation) (*ManagementPermissionRepresentation, error) {
 	const errMessage = "could not update client management permissions"
 
 	var result ManagementPermissionRepresentation
@@ -1674,7 +1674,7 @@ func (g *GoCloak) GetComponentsWithParams(ctx context.Context, token, realm stri
 }
 
 // GetComponent get exactly one component by ID
-func (g *GoCloak) GetComponent(ctx context.Context, token, realm string, componentID string) (*Component, error) {
+func (g *GoCloak) GetComponent(ctx context.Context, token, realm, componentID string) (*Component, error) {
 	const errMessage = "could not get components"
 	var result *Component
 
@@ -1844,7 +1844,7 @@ func (g *GoCloak) GetGroups(ctx context.Context, token, realm string, params Get
 
 // GetGroupManagementPermissions returns whether group Authorization permissions have been initialized or not and a reference
 // to the managed permissions
-func (g *GoCloak) GetGroupManagementPermissions(ctx context.Context, token, realm string, idOfGroup string) (*ManagementPermissionRepresentation, error) {
+func (g *GoCloak) GetGroupManagementPermissions(ctx context.Context, token, realm, idOfGroup string) (*ManagementPermissionRepresentation, error) {
 	const errMessage = "could not get management permissions"
 
 	var result ManagementPermissionRepresentation
@@ -1860,7 +1860,7 @@ func (g *GoCloak) GetGroupManagementPermissions(ctx context.Context, token, real
 }
 
 // GetGroupsByRole gets groups assigned with a specific role of a realm
-func (g *GoCloak) GetGroupsByRole(ctx context.Context, token, realm string, roleName string) ([]*Group, error) {
+func (g *GoCloak) GetGroupsByRole(ctx context.Context, token, realm, roleName string) ([]*Group, error) {
 	const errMessage = "could not get groups"
 
 	var result []*Group
@@ -1876,7 +1876,7 @@ func (g *GoCloak) GetGroupsByRole(ctx context.Context, token, realm string, role
 }
 
 // GetGroupsByClientRole gets groups with specified roles assigned of given client within a realm
-func (g *GoCloak) GetGroupsByClientRole(ctx context.Context, token, realm string, roleName string, clientID string) ([]*Group, error) {
+func (g *GoCloak) GetGroupsByClientRole(ctx context.Context, token, realm, roleName, clientID string) ([]*Group, error) {
 	const errMessage = "could not get groups"
 
 	var result []*Group
@@ -2123,7 +2123,7 @@ func (g *GoCloak) GetClients(ctx context.Context, token, realm string, params Ge
 
 // GetClientManagementPermissions returns whether client Authorization permissions have been initialized or not and a reference
 // to the managed permissions
-func (g *GoCloak) GetClientManagementPermissions(ctx context.Context, token, realm string, idOfClient string) (*ManagementPermissionRepresentation, error) {
+func (g *GoCloak) GetClientManagementPermissions(ctx context.Context, token, realm, idOfClient string) (*ManagementPermissionRepresentation, error) {
 	const errMessage = "could not get management permissions"
 
 	var result ManagementPermissionRepresentation
@@ -2153,7 +2153,7 @@ func UserAttributeContains(attributes map[string][]string, attribute, value stri
 // -----------
 
 // CreateRealmRole creates a role in a realm
-func (g *GoCloak) CreateRealmRole(ctx context.Context, token string, realm string, role Role) (string, error) {
+func (g *GoCloak) CreateRealmRole(ctx context.Context, token, realm string, role Role) (string, error) {
 	const errMessage = "could not create realm role"
 
 	resp, err := g.GetRequestWithBearerAuth(ctx, token).
@@ -2582,7 +2582,7 @@ func (g *GoCloak) GetAuthenticationFlows(ctx context.Context, token, realm strin
 }
 
 // GetAuthenticationFlow get an authentication flow with the given ID
-func (g *GoCloak) GetAuthenticationFlow(ctx context.Context, token, realm string, authenticationFlowID string) (*AuthenticationFlowRepresentation, error) {
+func (g *GoCloak) GetAuthenticationFlow(ctx context.Context, token, realm, authenticationFlowID string) (*AuthenticationFlowRepresentation, error) {
 	const errMessage = "could not retrieve authentication flows"
 	var result *AuthenticationFlowRepresentation
 	resp, err := g.GetRequestWithBearerAuth(ctx, token).
@@ -2731,7 +2731,7 @@ func (g *GoCloak) GetUserByID(ctx context.Context, accessToken, realm, userID st
 }
 
 // GetUserCount gets the user count in the realm
-func (g *GoCloak) GetUserCount(ctx context.Context, token string, realm string, params GetUsersParams) (int, error) {
+func (g *GoCloak) GetUserCount(ctx context.Context, token, realm string, params GetUsersParams) (int, error) {
 	const errMessage = "could not get user count"
 
 	var result int
@@ -3060,7 +3060,7 @@ func (g *GoCloak) GetUserBruteForceDetectionStatus(ctx context.Context, accessTo
 // ------------------
 
 // CreateIdentityProvider creates an identity provider in a realm
-func (g *GoCloak) CreateIdentityProvider(ctx context.Context, token string, realm string, providerRep IdentityProviderRepresentation) (string, error) {
+func (g *GoCloak) CreateIdentityProvider(ctx context.Context, token, realm string, providerRep IdentityProviderRepresentation) (string, error) {
 	const errMessage = "could not create identity provider"
 
 	resp, err := g.GetRequestWithBearerAuth(ctx, token).
@@ -3198,7 +3198,7 @@ func (g *GoCloak) CreateIdentityProviderMapper(ctx context.Context, token, realm
 }
 
 // GetIdentityProviderMapper gets the mapper by id for the given identity provider alias in a realm
-func (g *GoCloak) GetIdentityProviderMapper(ctx context.Context, token string, realm string, alias string, mapperID string) (*IdentityProviderMapper, error) {
+func (g *GoCloak) GetIdentityProviderMapper(ctx context.Context, token, realm, alias, mapperID string) (*IdentityProviderMapper, error) {
 	const errMessage = "could not get identity provider mapper"
 
 	result := IdentityProviderMapper{}
@@ -3405,7 +3405,7 @@ func (g *GoCloak) UpdateResourceClient(ctx context.Context, token, realm string,
 }
 
 // CreateResource creates a resource associated with the client, using access token from admin
-func (g *GoCloak) CreateResource(ctx context.Context, token, realm string, idOfClient string, resource ResourceRepresentation) (*ResourceRepresentation, error) {
+func (g *GoCloak) CreateResource(ctx context.Context, token, realm, idOfClient string, resource ResourceRepresentation) (*ResourceRepresentation, error) {
 	const errMessage = "could not create resource"
 
 	var result ResourceRepresentation
@@ -3513,7 +3513,7 @@ func (g *GoCloak) CreateScope(ctx context.Context, token, realm, idOfClient stri
 }
 
 // GetPermissionScope gets the permission scope associated with the client
-func (g *GoCloak) GetPermissionScope(ctx context.Context, token, realm, idOfClient string, idOfScope string) (*PolicyRepresentation, error) {
+func (g *GoCloak) GetPermissionScope(ctx context.Context, token, realm, idOfClient, idOfScope string) (*PolicyRepresentation, error) {
 	const errMessage = "could not get permission scope"
 
 	var result PolicyRepresentation
@@ -3530,7 +3530,7 @@ func (g *GoCloak) GetPermissionScope(ctx context.Context, token, realm, idOfClie
 }
 
 // UpdatePermissionScope updates a permission scope associated with the client
-func (g *GoCloak) UpdatePermissionScope(ctx context.Context, token, realm, idOfClient string, idOfScope string, policy PolicyRepresentation) error {
+func (g *GoCloak) UpdatePermissionScope(ctx context.Context, token, realm, idOfClient, idOfScope string, policy PolicyRepresentation) error {
 	const errMessage = "could not create permission scope"
 
 	resp, err := g.GetRequestWithBearerAuth(ctx, token).
@@ -3590,7 +3590,7 @@ func (g *GoCloak) GetPolicies(ctx context.Context, token, realm, idOfClient stri
 		return nil, errors.Wrap(err, errMessage)
 	}
 
-	compResult, err := g.compareVersions("20.0.0", token, ctx)
+	compResult, err := g.compareVersions(ctx, "20.0.0", token)
 	if err != nil {
 		return nil, err
 	}
@@ -3622,7 +3622,7 @@ func (g *GoCloak) CreatePolicy(ctx context.Context, token, realm, idOfClient str
 		return nil, errors.New("type of a policy required")
 	}
 
-	compResult, err := g.compareVersions("20.0.0", token, ctx)
+	compResult, err := g.compareVersions(ctx, "20.0.0", token)
 	if err != nil {
 		return nil, err
 	}
@@ -3655,7 +3655,7 @@ func (g *GoCloak) UpdatePolicy(ctx context.Context, token, realm, idOfClient str
 		return errors.New("ID of a policy required")
 	}
 
-	compResult, err := g.compareVersions("20.0.0", token, ctx)
+	compResult, err := g.compareVersions(ctx, "20.0.0", token)
 	if err != nil {
 		return err
 	}
@@ -3923,7 +3923,6 @@ func checkPermissionTicketParams(permissions []CreatePermissionTicketParams) err
 	}
 
 	for _, pt := range permissions {
-
 		if NilOrEmpty(pt.ResourceID) {
 			return errors.New("resourceID required for permission ticket")
 		}
@@ -4220,7 +4219,7 @@ func (g *GoCloak) MoveCredentialToFirst(ctx context.Context, token, realm, userI
 }
 
 // GetEvents returns events
-func (g *GoCloak) GetEvents(ctx context.Context, token string, realm string, params GetEventsParams) ([]*EventRepresentation, error) {
+func (g *GoCloak) GetEvents(ctx context.Context, token, realm string, params GetEventsParams) ([]*EventRepresentation, error) {
 	const errMessage = "could not get events"
 
 	queryParams, err := GetQueryParams(params)
@@ -4298,7 +4297,7 @@ func (g *GoCloak) CreateClientScopesScopeMappingsRealmRoles(ctx context.Context,
 }
 
 // RegisterRequiredAction creates a required action for a given realm
-func (g *GoCloak) RegisterRequiredAction(ctx context.Context, token string, realm string, requiredAction RequiredActionProviderRepresentation) error {
+func (g *GoCloak) RegisterRequiredAction(ctx context.Context, token, realm string, requiredAction RequiredActionProviderRepresentation) error {
 	const errMessage = "could not create required action"
 
 	resp, err := g.GetRequestWithBearerAuth(ctx, token).
@@ -4313,7 +4312,7 @@ func (g *GoCloak) RegisterRequiredAction(ctx context.Context, token string, real
 }
 
 // GetUnregisteredRequiredActions gets a list of unregistered required actions for a given realm
-func (g *GoCloak) GetUnregisteredRequiredActions(ctx context.Context, token string, realm string) ([]*UnregisteredRequiredActionProviderRepresentation, error) {
+func (g *GoCloak) GetUnregisteredRequiredActions(ctx context.Context, token, realm string) ([]*UnregisteredRequiredActionProviderRepresentation, error) {
 	const errMessage = "could not get unregistered required actions"
 
 	var result []*UnregisteredRequiredActionProviderRepresentation
@@ -4330,7 +4329,7 @@ func (g *GoCloak) GetUnregisteredRequiredActions(ctx context.Context, token stri
 }
 
 // GetRequiredActions gets a list of required actions for a given realm
-func (g *GoCloak) GetRequiredActions(ctx context.Context, token string, realm string) ([]*RequiredActionProviderRepresentation, error) {
+func (g *GoCloak) GetRequiredActions(ctx context.Context, token, realm string) ([]*RequiredActionProviderRepresentation, error) {
 	const errMessage = "could not get required actions"
 	var result []*RequiredActionProviderRepresentation
 
@@ -4346,7 +4345,7 @@ func (g *GoCloak) GetRequiredActions(ctx context.Context, token string, realm st
 }
 
 // GetRequiredAction gets a required action for a given realm
-func (g *GoCloak) GetRequiredAction(ctx context.Context, token string, realm string, alias string) (*RequiredActionProviderRepresentation, error) {
+func (g *GoCloak) GetRequiredAction(ctx context.Context, token, realm, alias string) (*RequiredActionProviderRepresentation, error) {
 	const errMessage = "could not get required action"
 	var result RequiredActionProviderRepresentation
 
@@ -4366,7 +4365,7 @@ func (g *GoCloak) GetRequiredAction(ctx context.Context, token string, realm str
 }
 
 // UpdateRequiredAction updates a required action for a given realm
-func (g *GoCloak) UpdateRequiredAction(ctx context.Context, token string, realm string, requiredAction RequiredActionProviderRepresentation) error {
+func (g *GoCloak) UpdateRequiredAction(ctx context.Context, token, realm string, requiredAction RequiredActionProviderRepresentation) error {
 	const errMessage = "could not update required action"
 
 	if NilOrEmpty(requiredAction.ProviderID) {
@@ -4380,7 +4379,7 @@ func (g *GoCloak) UpdateRequiredAction(ctx context.Context, token string, realm 
 }
 
 // DeleteRequiredAction updates a required action for a given realm
-func (g *GoCloak) DeleteRequiredAction(ctx context.Context, token string, realm string, alias string) error {
+func (g *GoCloak) DeleteRequiredAction(ctx context.Context, token, realm, alias string) error {
 	const errMessage = "could not delete required action"
 
 	if alias == "" {

--- a/client_benchmark_test.go
+++ b/client_benchmark_test.go
@@ -4,9 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/Nerzal/gocloak/v13"
+	"github.com/stretchr/testify/assert"
 )
 
 func BenchmarkLogin(b *testing.B) {

--- a/client_benchmark_test.go
+++ b/client_benchmark_test.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Nerzal/gocloak/v13"
-
 	"github.com/stretchr/testify/assert"
+
+	"github.com/Nerzal/gocloak/v13"
 )
 
 func BenchmarkLogin(b *testing.B) {

--- a/client_benchmark_test.go
+++ b/client_benchmark_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Nerzal/gocloak/v13"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/Nerzal/gocloak/v13"
 )
 
 func BenchmarkLogin(b *testing.B) {

--- a/client_test.go
+++ b/client_test.go
@@ -21,11 +21,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Nerzal/gocloak/v13"
 	"github.com/go-resty/resty/v2"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/pkcs12"
+
+	"github.com/Nerzal/gocloak/v13"
 )
 
 type configAdmin struct {

--- a/client_test.go
+++ b/client_test.go
@@ -476,19 +476,19 @@ type RestyLogWriter struct {
 	t testing.TB
 }
 
-func (w *RestyLogWriter) Errorf(format string, v ...interface{}) {
+func (w *RestyLogWriter) Errorf(format string, v ...any) {
 	w.write("[ERROR] "+format, v...)
 }
 
-func (w *RestyLogWriter) Warnf(format string, v ...interface{}) {
+func (w *RestyLogWriter) Warnf(format string, v ...any) {
 	w.write("[WARN] "+format, v...)
 }
 
-func (w *RestyLogWriter) Debugf(format string, v ...interface{}) {
+func (w *RestyLogWriter) Debugf(format string, v ...any) {
 	w.write("[DEBUG] "+format, v...)
 }
 
-func (w *RestyLogWriter) write(format string, v ...interface{}) {
+func (w *RestyLogWriter) write(format string, v ...any) {
 	w.t.Logf(format, v...)
 }
 
@@ -3303,7 +3303,6 @@ func Test_GetUserBruteForceDetectionStatus(t *testing.T) {
 		token.AccessToken,
 		*realm)
 	require.NoError(t, err, "UpdateRealm failed")
-
 }
 
 func Test_CreateUserCustomAttributes(t *testing.T) {
@@ -6289,7 +6288,7 @@ func Test_CreatePermissionTicket(t *testing.T) {
 	require.NoError(t, err, "CreatePermissionTicket failed")
 	t.Logf("Created PermissionTicket: %+v", *(ticket.Ticket))
 
-	pt, err := jwt.ParseWithClaims(*(ticket.Ticket), &gocloak.PermissionTicketRepresentation{}, func(_ *jwt.Token) (interface{}, error) {
+	pt, err := jwt.ParseWithClaims(*(ticket.Ticket), &gocloak.PermissionTicketRepresentation{}, func(_ *jwt.Token) (any, error) {
 		return []byte(""), nil
 	})
 
@@ -6610,7 +6609,7 @@ func Test_GetClientsWithPagination(t *testing.T) {
 	defer tearDown()
 	t.Log(createdClientID)
 	first := 0
-	max := 1
+	maxParam := 1
 	// Looking for a created client
 	clients, err := client.GetClients(
 		context.Background(),
@@ -6618,11 +6617,11 @@ func Test_GetClientsWithPagination(t *testing.T) {
 		cfg.GoCloak.Realm,
 		gocloak.GetClientsParams{
 			First: &first,
-			Max:   &max,
+			Max:   &maxParam,
 		},
 	)
 	require.NoError(t, err)
-	require.Equal(t, max, len(clients))
+	require.Equal(t, maxParam, len(clients))
 }
 
 func Test_ImportIdentityProviderConfig(t *testing.T) {

--- a/client_test.go
+++ b/client_test.go
@@ -21,12 +21,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Nerzal/gocloak/v13"
 	"github.com/go-resty/resty/v2"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/pkcs12"
-
-	"github.com/Nerzal/gocloak/v13"
 )
 
 type configAdmin struct {
@@ -1243,11 +1242,6 @@ func Test_GroupPermissions(t *testing.T) {
 		Description: gocloak.StringP("Policy Description"),
 		Type:        gocloak.StringP("client"),
 		Logic:       gocloak.POSITIVE,
-		// ClientPolicyRepresentation: gocloak.ClientPolicyRepresentation{
-		// 	Clients: &[]string{
-		// 		gocloakClientID,
-		// 	},
-		// },
 	})
 
 	for _, scopeID := range *updatedGroupPermission.ScopePermissions {

--- a/client_test.go
+++ b/client_test.go
@@ -21,12 +21,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Nerzal/gocloak/v13"
 	"github.com/go-resty/resty/v2"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/pkcs12"
-
-	"github.com/Nerzal/gocloak/v13"
 )
 
 type configAdmin struct {
@@ -820,7 +819,7 @@ func Test_LoginClient_UnknownRealm(t *testing.T) {
 		cfg.GoCloak.ClientSecret,
 		"ThisRealmDoesNotExist")
 	require.Error(t, err, "Login shouldn't be successful")
-	require.EqualError(t, err, "404 Not Found: Realm does not exist")
+	require.ErrorContains(t, err, "404 Not Found: Realm does not exist")
 }
 
 func Test_GetIssuer(t *testing.T) {
@@ -1243,11 +1242,11 @@ func Test_GroupPermissions(t *testing.T) {
 		Description: gocloak.StringP("Policy Description"),
 		Type:        gocloak.StringP("client"),
 		Logic:       gocloak.POSITIVE,
-		ClientPolicyRepresentation: gocloak.ClientPolicyRepresentation{
-			Clients: &[]string{
-				gocloakClientID,
-			},
-		},
+		// ClientPolicyRepresentation: gocloak.ClientPolicyRepresentation{
+		// 	Clients: &[]string{
+		// 		gocloakClientID,
+		// 	},
+		// },
 	})
 
 	for _, scopeID := range *updatedGroupPermission.ScopePermissions {
@@ -5370,11 +5369,6 @@ func Test_CreateListGetUpdateDeletePolicy(t *testing.T) {
 		Description: gocloak.StringP("Policy Description"),
 		Type:        gocloak.StringP("client"),
 		Logic:       gocloak.NEGATIVE,
-		ClientPolicyRepresentation: gocloak.ClientPolicyRepresentation{
-			Clients: &[]string{
-				gocloakClientID,
-			},
-		},
 	})
 	// Delete
 	defer tearDown()
@@ -5443,11 +5437,6 @@ func Test_CreateListGetUpdateDeletePolicy(t *testing.T) {
 			Description: createdPolicy.Description,
 			Type:        createdPolicy.Type,
 			Logic:       createdPolicy.Logic,
-			ClientPolicyRepresentation: gocloak.ClientPolicyRepresentation{
-				Clients: &[]string{
-					gocloakClientID,
-				},
-			},
 		},
 	)
 	require.NoError(t, err, "UpdatePolicy failed")
@@ -5474,11 +5463,6 @@ func Test_ErrorsGetAuthorizationPolicyAssociatedPolicies(t *testing.T) {
 		Description: gocloak.StringP("Policy Description"),
 		Type:        gocloak.StringP("client"),
 		Logic:       gocloak.POSITIVE,
-		ClientPolicyRepresentation: gocloak.ClientPolicyRepresentation{
-			Clients: &[]string{
-				gocloakClientID,
-			},
-		},
 	})
 
 	// Create Resource
@@ -5526,11 +5510,6 @@ func Test_GetAuthorizationPolicyAssociatedPolicies(t *testing.T) {
 		Description: gocloak.StringP("Policy Description"),
 		Type:        gocloak.StringP("client"),
 		Logic:       gocloak.POSITIVE,
-		ClientPolicyRepresentation: gocloak.ClientPolicyRepresentation{
-			Clients: &[]string{
-				gocloakClientID,
-			},
-		},
 	})
 
 	// Create Resource
@@ -5579,11 +5558,6 @@ func Test_ErrorsGetAuthorizationPolicyResources(t *testing.T) {
 		Description: gocloak.StringP("Policy Description"),
 		Type:        gocloak.StringP("client"),
 		Logic:       gocloak.POSITIVE,
-		ClientPolicyRepresentation: gocloak.ClientPolicyRepresentation{
-			Clients: &[]string{
-				gocloakClientID,
-			},
-		},
 	})
 
 	// Create Resource
@@ -5629,11 +5603,6 @@ func Test_GetAuthorizationPolicyResources(t *testing.T) {
 		Description: gocloak.StringP("Policy Description"),
 		Type:        gocloak.StringP("client"),
 		Logic:       gocloak.POSITIVE,
-		ClientPolicyRepresentation: gocloak.ClientPolicyRepresentation{
-			Clients: &[]string{
-				gocloakClientID,
-			},
-		},
 	})
 
 	// Create Resource
@@ -5686,11 +5655,6 @@ func Test_ErrorsGetAuthorizationPolicyScopes(t *testing.T) {
 			Description: gocloak.StringP("Policy Description"),
 			Type:        gocloak.StringP("client"),
 			Logic:       gocloak.POSITIVE,
-			ClientPolicyRepresentation: gocloak.ClientPolicyRepresentation{
-				Clients: &[]string{
-					gocloakClientID,
-				},
-			},
 		})
 	})
 
@@ -5749,11 +5713,6 @@ func Test_GetAuthorizationPolicyScopes(t *testing.T) {
 		Description: gocloak.StringP("Policy Description"),
 		Type:        gocloak.StringP("client"),
 		Logic:       gocloak.POSITIVE,
-		ClientPolicyRepresentation: gocloak.ClientPolicyRepresentation{
-			Clients: &[]string{
-				gocloakClientID,
-			},
-		},
 	})
 
 	// Create Resource
@@ -5933,11 +5892,6 @@ func Test_ClientPolicy(t *testing.T) {
 		Name:        GetRandomNameP("PolicyName"),
 		Description: gocloak.StringP("Client Policy"),
 		Type:        gocloak.StringP("client"),
-		ClientPolicyRepresentation: gocloak.ClientPolicyRepresentation{
-			Clients: &[]string{
-				gocloakClientID,
-			},
-		},
 	})
 	// Delete
 	defer tearDown()
@@ -6001,11 +5955,6 @@ func Test_AggregatedPolicy(t *testing.T) {
 		Name:        GetRandomNameP("PolicyName"),
 		Description: gocloak.StringP("Client Policy"),
 		Type:        gocloak.StringP("client"),
-		ClientPolicyRepresentation: gocloak.ClientPolicyRepresentation{
-			Clients: &[]string{
-				gocloakClientID,
-			},
-		},
 	})
 	defer tearDownClient()
 
@@ -6014,11 +5963,6 @@ func Test_AggregatedPolicy(t *testing.T) {
 		Description: gocloak.StringP("JS Policy"),
 		Type:        gocloak.StringP("client"),
 		Logic:       gocloak.POSITIVE,
-		ClientPolicyRepresentation: gocloak.ClientPolicyRepresentation{
-			Clients: &[]string{
-				gocloakClientID,
-			},
-		},
 	})
 	// Delete
 	defer tearDownClient1()
@@ -6321,11 +6265,6 @@ func Test_CreateListGetUpdateDeletePermission(t *testing.T) {
 		Description: gocloak.StringP("Client Policy"),
 		Type:        gocloak.StringP("client"),
 		Logic:       gocloak.POSITIVE,
-		ClientPolicyRepresentation: gocloak.ClientPolicyRepresentation{
-			Clients: &[]string{
-				gocloakClientID,
-			},
-		},
 	})
 	// Delete
 	defer tearDownPolicy()

--- a/model_test.go
+++ b/model_test.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/Nerzal/gocloak/v13"
-
 	"github.com/stretchr/testify/assert"
+
+	"github.com/Nerzal/gocloak/v13"
 )
 
 func TestStringOrArray_Unmarshal(t *testing.T) {

--- a/model_test.go
+++ b/model_test.go
@@ -5,8 +5,9 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/Nerzal/gocloak/v13"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/Nerzal/gocloak/v13"
 )
 
 func TestStringOrArray_Unmarshal(t *testing.T) {

--- a/model_test.go
+++ b/model_test.go
@@ -5,9 +5,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/Nerzal/gocloak/v13"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestStringOrArray_Unmarshal(t *testing.T) {
@@ -290,7 +289,6 @@ func TestStringerOmitEmpty(t *testing.T) {
 		&gocloak.PolicyRepresentation{},
 		&gocloak.RolePolicyRepresentation{},
 		&gocloak.JSPolicyRepresentation{},
-		&gocloak.ClientPolicyRepresentation{},
 		&gocloak.TimePolicyRepresentation{},
 		&gocloak.UserPolicyRepresentation{},
 		&gocloak.AggregatedPolicyRepresentation{},

--- a/model_test.go
+++ b/model_test.go
@@ -5,9 +5,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/Nerzal/gocloak/v13"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestStringOrArray_Unmarshal(t *testing.T) {

--- a/models.go
+++ b/models.go
@@ -14,7 +14,7 @@ import (
 // will add additional double quotes.
 // "string" tag allows to convert the non-string fields of a structure to map[string]string.
 // "omitempty" allows to skip the fields with default values.
-func GetQueryParams(s interface{}) (map[string]string, error) {
+func GetQueryParams(s any) (map[string]string, error) {
 	// if obj, ok := s.(GetGroupsParams); ok {
 	// 	obj.OnMarshal()
 	// 	s = obj
@@ -209,7 +209,7 @@ type User struct {
 	Email                      *string                     `json:"email,omitempty"`
 	FederationLink             *string                     `json:"federationLink,omitempty"`
 	Attributes                 *map[string][]string        `json:"attributes,omitempty"`
-	DisableableCredentialTypes *[]interface{}              `json:"disableableCredentialTypes,omitempty"`
+	DisableableCredentialTypes *[]any                      `json:"disableableCredentialTypes,omitempty"`
 	RequiredActions            *[]string                   `json:"requiredActions,omitempty"`
 	Access                     *map[string]bool            `json:"access,omitempty"`
 	ClientRoles                *map[string][]string        `json:"clientRoles,omitempty"`
@@ -464,7 +464,7 @@ type ProtocolMappersConfig struct {
 
 // Client is a ClientRepresentation
 type Client struct {
-	Access                             *map[string]interface{}         `json:"access,omitempty"`
+	Access                             *map[string]any                 `json:"access,omitempty"`
 	AdminURL                           *string                         `json:"adminUrl,omitempty"`
 	Attributes                         *map[string]string              `json:"attributes,omitempty"`
 	AuthenticationFlowBindingOverrides *map[string]string              `json:"authenticationFlowBindingOverrides,omitempty"`
@@ -529,12 +529,12 @@ type RoleDefinition struct {
 
 // AdapterConfiguration represents adapter configuration of a client
 type AdapterConfiguration struct {
-	Realm            *string     `json:"realm"`
-	AuthServerURL    *string     `json:"auth-server-url"`
-	SSLRequired      *string     `json:"ssl-required"`
-	Resource         *string     `json:"resource"`
-	Credentials      interface{} `json:"credentials"`
-	ConfidentialPort *int        `json:"confidential-port"`
+	Realm            *string `json:"realm"`
+	AuthServerURL    *string `json:"auth-server-url"`
+	SSLRequired      *string `json:"ssl-required"`
+	Resource         *string `json:"resource"`
+	Credentials      any     `json:"credentials"`
+	ConfidentialPort *int    `json:"confidential-port"`
 }
 
 // PolicyEnforcementMode is an enum type for PolicyEnforcementMode of ResourceServerRepresentation
@@ -736,122 +736,122 @@ type RolesRepresentation struct {
 
 // RealmRepresentation represents a realm
 type RealmRepresentation struct {
-	AccessCodeLifespan                                        *int                      `json:"accessCodeLifespan,omitempty"`
-	AccessCodeLifespanLogin                                   *int                      `json:"accessCodeLifespanLogin,omitempty"`
-	AccessCodeLifespanUserAction                              *int                      `json:"accessCodeLifespanUserAction,omitempty"`
-	AccessTokenLifespan                                       *int                      `json:"accessTokenLifespan,omitempty"`
-	AccessTokenLifespanForImplicitFlow                        *int                      `json:"accessTokenLifespanForImplicitFlow,omitempty"`
-	AccountTheme                                              *string                   `json:"accountTheme,omitempty"`
-	ActionTokenGeneratedByAdminLifespan                       *int                      `json:"actionTokenGeneratedByAdminLifespan,omitempty"`
-	ActionTokenGeneratedByUserLifespan                        *int                      `json:"actionTokenGeneratedByUserLifespan,omitempty"`
-	AdminEventsDetailsEnabled                                 *bool                     `json:"adminEventsDetailsEnabled,omitempty"`
-	AdminEventsEnabled                                        *bool                     `json:"adminEventsEnabled,omitempty"`
-	AdminTheme                                                *string                   `json:"adminTheme,omitempty"`
-	Attributes                                                *map[string]string        `json:"attributes,omitempty"`
-	AuthenticationFlows                                       *[]interface{}            `json:"authenticationFlows,omitempty"`
-	AuthenticatorConfig                                       *[]interface{}            `json:"authenticatorConfig,omitempty"`
-	BrowserFlow                                               *string                   `json:"browserFlow,omitempty"`
-	BrowserSecurityHeaders                                    *map[string]string        `json:"browserSecurityHeaders,omitempty"`
-	BruteForceProtected                                       *bool                     `json:"bruteForceProtected,omitempty"`
-	ClientAuthenticationFlow                                  *string                   `json:"clientAuthenticationFlow,omitempty"`
-	ClientPolicies                                            *map[string][]interface{} `json:"clientPolicies,omitempty"`
-	ClientProfiles                                            *map[string][]interface{} `json:"clientProfiles,omitempty"`
-	ClientScopeMappings                                       *map[string][]interface{} `json:"clientScopeMappings,omitempty"`
-	ClientScopes                                              *[]ClientScope            `json:"clientScopes,omitempty"`
-	Clients                                                   *[]Client                 `json:"clients,omitempty"`
-	Components                                                interface{}               `json:"components,omitempty"`
-	DefaultDefaultClientScopes                                *[]string                 `json:"defaultDefaultClientScopes,omitempty"`
-	DefaultGroups                                             *[]string                 `json:"defaultGroups,omitempty"`
-	DefaultLocale                                             *string                   `json:"defaultLocale,omitempty"`
-	DefaultOptionalClientScopes                               *[]string                 `json:"defaultOptionalClientScopes,omitempty"`
-	DefaultRole                                               *Role                     `json:"defaultRole,omitempty"`
-	DefaultRoles                                              *[]string                 `json:"defaultRoles,omitempty"`
-	DefaultSignatureAlgorithm                                 *string                   `json:"defaultSignatureAlgorithm,omitempty"`
-	DirectGrantFlow                                           *string                   `json:"directGrantFlow,omitempty"`
-	DisplayName                                               *string                   `json:"displayName,omitempty"`
-	DisplayNameHTML                                           *string                   `json:"displayNameHtml,omitempty"`
-	DockerAuthenticationFlow                                  *string                   `json:"dockerAuthenticationFlow,omitempty"`
-	DuplicateEmailsAllowed                                    *bool                     `json:"duplicateEmailsAllowed,omitempty"`
-	EditUsernameAllowed                                       *bool                     `json:"editUsernameAllowed,omitempty"`
-	EmailTheme                                                *string                   `json:"emailTheme,omitempty"`
-	Enabled                                                   *bool                     `json:"enabled,omitempty"`
-	EnabledEventTypes                                         *[]string                 `json:"enabledEventTypes,omitempty"`
-	EventsEnabled                                             *bool                     `json:"eventsEnabled,omitempty"`
-	EventsExpiration                                          *int64                    `json:"eventsExpiration,omitempty"`
-	EventsListeners                                           *[]string                 `json:"eventsListeners,omitempty"`
-	FailureFactor                                             *int                      `json:"failureFactor,omitempty"`
-	FederatedUsers                                            *[]interface{}            `json:"federatedUsers,omitempty"`
-	Groups                                                    *[]interface{}            `json:"groups,omitempty"`
-	ID                                                        *string                   `json:"id,omitempty"`
-	IdentityProviderMappers                                   *[]interface{}            `json:"identityProviderMappers,omitempty"`
-	IdentityProviders                                         *[]interface{}            `json:"identityProviders,omitempty"`
-	InternationalizationEnabled                               *bool                     `json:"internationalizationEnabled,omitempty"`
-	KeycloakVersion                                           *string                   `json:"keycloakVersion,omitempty"`
-	LoginTheme                                                *string                   `json:"loginTheme,omitempty"`
-	LoginWithEmailAllowed                                     *bool                     `json:"loginWithEmailAllowed,omitempty"`
-	MaxDeltaTimeSeconds                                       *int                      `json:"maxDeltaTimeSeconds,omitempty"`
-	MaxFailureWaitSeconds                                     *int                      `json:"maxFailureWaitSeconds,omitempty"`
-	MinimumQuickLoginWaitSeconds                              *int                      `json:"minimumQuickLoginWaitSeconds,omitempty"`
-	NotBefore                                                 *int                      `json:"notBefore,omitempty"`
-	OfflineSessionIdleTimeout                                 *int                      `json:"offlineSessionIdleTimeout,omitempty"`
-	OfflineSessionMaxLifespan                                 *int                      `json:"offlineSessionMaxLifespan,omitempty"`
-	OfflineSessionMaxLifespanEnabled                          *bool                     `json:"offlineSessionMaxLifespanEnabled,omitempty"`
-	OtpPolicyAlgorithm                                        *string                   `json:"otpPolicyAlgorithm,omitempty"`
-	OtpPolicyDigits                                           *int                      `json:"otpPolicyDigits,omitempty"`
-	OtpPolicyInitialCounter                                   *int                      `json:"otpPolicyInitialCounter,omitempty"`
-	OtpPolicyLookAheadWindow                                  *int                      `json:"otpPolicyLookAheadWindow,omitempty"`
-	OtpPolicyPeriod                                           *int                      `json:"otpPolicyPeriod,omitempty"`
-	OtpPolicyType                                             *string                   `json:"otpPolicyType,omitempty"`
-	OtpSupportedApplications                                  *[]string                 `json:"otpSupportedApplications,omitempty"`
-	PasswordPolicy                                            *string                   `json:"passwordPolicy,omitempty"`
-	PermanentLockout                                          *bool                     `json:"permanentLockout,omitempty"`
-	ProtocolMappers                                           *[]interface{}            `json:"protocolMappers,omitempty"`
-	QuickLoginCheckMilliSeconds                               *int64                    `json:"quickLoginCheckMilliSeconds,omitempty"`
-	Realm                                                     *string                   `json:"realm,omitempty"`
-	RefreshTokenMaxReuse                                      *int                      `json:"refreshTokenMaxReuse,omitempty"`
-	RegistrationAllowed                                       *bool                     `json:"registrationAllowed,omitempty"`
-	RegistrationEmailAsUsername                               *bool                     `json:"registrationEmailAsUsername,omitempty"`
-	RegistrationFlow                                          *string                   `json:"registrationFlow,omitempty"`
-	RememberMe                                                *bool                     `json:"rememberMe,omitempty"`
-	RequiredActions                                           *[]interface{}            `json:"requiredActions,omitempty"`
-	ResetCredentialsFlow                                      *string                   `json:"resetCredentialsFlow,omitempty"`
-	ResetPasswordAllowed                                      *bool                     `json:"resetPasswordAllowed,omitempty"`
-	RevokeRefreshToken                                        *bool                     `json:"revokeRefreshToken,omitempty"`
-	Roles                                                     *RolesRepresentation      `json:"roles,omitempty"`
-	ScopeMappings                                             *[]interface{}            `json:"scopeMappings,omitempty"`
-	SMTPServer                                                *map[string]string        `json:"smtpServer,omitempty"`
-	SslRequired                                               *string                   `json:"sslRequired,omitempty"`
-	SsoSessionIdleTimeout                                     *int                      `json:"ssoSessionIdleTimeout,omitempty"`
-	SsoSessionIdleTimeoutRememberMe                           *int                      `json:"ssoSessionIdleTimeoutRememberMe,omitempty"`
-	SsoSessionMaxLifespan                                     *int                      `json:"ssoSessionMaxLifespan,omitempty"`
-	SsoSessionMaxLifespanRememberMe                           *int                      `json:"ssoSessionMaxLifespanRememberMe,omitempty"`
-	SupportedLocales                                          *[]string                 `json:"supportedLocales,omitempty"`
-	UserFederationMappers                                     *[]interface{}            `json:"userFederationMappers,omitempty"`
-	UserFederationProviders                                   *[]interface{}            `json:"userFederationProviders,omitempty"`
-	UserManagedAccessAllowed                                  *bool                     `json:"userManagedAccessAllowed,omitempty"`
-	Users                                                     *[]User                   `json:"users,omitempty"`
-	VerifyEmail                                               *bool                     `json:"verifyEmail,omitempty"`
-	WaitIncrementSeconds                                      *int                      `json:"waitIncrementSeconds,omitempty"`
-	WebAuthnPolicyAcceptableAaguids                           *[]string                 `json:"webAuthnPolicyAcceptableAaguids,omitempty"`
-	WebAuthnPolicyAttestationConveyancePreference             *string                   `json:"webAuthnPolicyAttestationConveyancePreference,omitempty"`
-	WebAuthnPolicyAuthenticatorAttachment                     *string                   `json:"webAuthnPolicyAuthenticatorAttachment,omitempty"`
-	WebAuthnPolicyAvoidSameAuthenticatorRegister              *bool                     `json:"webAuthnPolicyAvoidSameAuthenticatorRegister,omitempty"`
-	WebAuthnPolicyCreateTimeout                               *int                      `json:"webAuthnPolicyCreateTimeout,omitempty"`
-	WebAuthnPolicyPasswordlessAcceptableAaguids               *[]string                 `json:"webAuthnPolicyPasswordlessAcceptableAaguids,omitempty"`
-	WebAuthnPolicyPasswordlessAttestationConveyancePreference *string                   `json:"webAuthnPolicyPasswordlessAttestationConveyancePreference,omitempty"`
-	WebAuthnPolicyPasswordlessAuthenticatorAttachment         *string                   `json:"webAuthnPolicyPasswordlessAuthenticatorAttachment,omitempty"`
-	WebAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister  *bool                     `json:"webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister,omitempty"`
-	WebAuthnPolicyPasswordlessCreateTimeout                   *int                      `json:"webAuthnPolicyPasswordlessCreateTimeout,omitempty"`
-	WebAuthnPolicyPasswordlessRequireResidentKey              *string                   `json:"webAuthnPolicyPasswordlessRequireResidentKey,omitempty"`
-	WebAuthnPolicyPasswordlessRpEntityName                    *string                   `json:"webAuthnPolicyPasswordlessRpEntityName,omitempty"`
-	WebAuthnPolicyPasswordlessRpID                            *string                   `json:"webAuthnPolicyPasswordlessRpId,omitempty"`
-	WebAuthnPolicyPasswordlessSignatureAlgorithms             *[]string                 `json:"webAuthnPolicyPasswordlessSignatureAlgorithms,omitempty"`
-	WebAuthnPolicyPasswordlessUserVerificationRequirement     *string                   `json:"webAuthnPolicyPasswordlessUserVerificationRequirement,omitempty"`
-	WebAuthnPolicyRequireResidentKey                          *string                   `json:"webAuthnPolicyRequireResidentKey,omitempty"`
-	WebAuthnPolicyRpEntityName                                *string                   `json:"webAuthnPolicyRpEntityName,omitempty"`
-	WebAuthnPolicyRpID                                        *string                   `json:"webAuthnPolicyRpId,omitempty"`
-	WebAuthnPolicySignatureAlgorithms                         *[]string                 `json:"webAuthnPolicySignatureAlgorithms,omitempty"`
-	WebAuthnPolicyUserVerificationRequirement                 *string                   `json:"webAuthnPolicyUserVerificationRequirement,omitempty"`
+	AccessCodeLifespan                                        *int                 `json:"accessCodeLifespan,omitempty"`
+	AccessCodeLifespanLogin                                   *int                 `json:"accessCodeLifespanLogin,omitempty"`
+	AccessCodeLifespanUserAction                              *int                 `json:"accessCodeLifespanUserAction,omitempty"`
+	AccessTokenLifespan                                       *int                 `json:"accessTokenLifespan,omitempty"`
+	AccessTokenLifespanForImplicitFlow                        *int                 `json:"accessTokenLifespanForImplicitFlow,omitempty"`
+	AccountTheme                                              *string              `json:"accountTheme,omitempty"`
+	ActionTokenGeneratedByAdminLifespan                       *int                 `json:"actionTokenGeneratedByAdminLifespan,omitempty"`
+	ActionTokenGeneratedByUserLifespan                        *int                 `json:"actionTokenGeneratedByUserLifespan,omitempty"`
+	AdminEventsDetailsEnabled                                 *bool                `json:"adminEventsDetailsEnabled,omitempty"`
+	AdminEventsEnabled                                        *bool                `json:"adminEventsEnabled,omitempty"`
+	AdminTheme                                                *string              `json:"adminTheme,omitempty"`
+	Attributes                                                *map[string]string   `json:"attributes,omitempty"`
+	AuthenticationFlows                                       *[]any               `json:"authenticationFlows,omitempty"`
+	AuthenticatorConfig                                       *[]any               `json:"authenticatorConfig,omitempty"`
+	BrowserFlow                                               *string              `json:"browserFlow,omitempty"`
+	BrowserSecurityHeaders                                    *map[string]string   `json:"browserSecurityHeaders,omitempty"`
+	BruteForceProtected                                       *bool                `json:"bruteForceProtected,omitempty"`
+	ClientAuthenticationFlow                                  *string              `json:"clientAuthenticationFlow,omitempty"`
+	ClientPolicies                                            *map[string][]any    `json:"clientPolicies,omitempty"`
+	ClientProfiles                                            *map[string][]any    `json:"clientProfiles,omitempty"`
+	ClientScopeMappings                                       *map[string][]any    `json:"clientScopeMappings,omitempty"`
+	ClientScopes                                              *[]ClientScope       `json:"clientScopes,omitempty"`
+	Clients                                                   *[]Client            `json:"clients,omitempty"`
+	Components                                                any                  `json:"components,omitempty"`
+	DefaultDefaultClientScopes                                *[]string            `json:"defaultDefaultClientScopes,omitempty"`
+	DefaultGroups                                             *[]string            `json:"defaultGroups,omitempty"`
+	DefaultLocale                                             *string              `json:"defaultLocale,omitempty"`
+	DefaultOptionalClientScopes                               *[]string            `json:"defaultOptionalClientScopes,omitempty"`
+	DefaultRole                                               *Role                `json:"defaultRole,omitempty"`
+	DefaultRoles                                              *[]string            `json:"defaultRoles,omitempty"`
+	DefaultSignatureAlgorithm                                 *string              `json:"defaultSignatureAlgorithm,omitempty"`
+	DirectGrantFlow                                           *string              `json:"directGrantFlow,omitempty"`
+	DisplayName                                               *string              `json:"displayName,omitempty"`
+	DisplayNameHTML                                           *string              `json:"displayNameHtml,omitempty"`
+	DockerAuthenticationFlow                                  *string              `json:"dockerAuthenticationFlow,omitempty"`
+	DuplicateEmailsAllowed                                    *bool                `json:"duplicateEmailsAllowed,omitempty"`
+	EditUsernameAllowed                                       *bool                `json:"editUsernameAllowed,omitempty"`
+	EmailTheme                                                *string              `json:"emailTheme,omitempty"`
+	Enabled                                                   *bool                `json:"enabled,omitempty"`
+	EnabledEventTypes                                         *[]string            `json:"enabledEventTypes,omitempty"`
+	EventsEnabled                                             *bool                `json:"eventsEnabled,omitempty"`
+	EventsExpiration                                          *int64               `json:"eventsExpiration,omitempty"`
+	EventsListeners                                           *[]string            `json:"eventsListeners,omitempty"`
+	FailureFactor                                             *int                 `json:"failureFactor,omitempty"`
+	FederatedUsers                                            *[]any               `json:"federatedUsers,omitempty"`
+	Groups                                                    *[]any               `json:"groups,omitempty"`
+	ID                                                        *string              `json:"id,omitempty"`
+	IdentityProviderMappers                                   *[]any               `json:"identityProviderMappers,omitempty"`
+	IdentityProviders                                         *[]any               `json:"identityProviders,omitempty"`
+	InternationalizationEnabled                               *bool                `json:"internationalizationEnabled,omitempty"`
+	KeycloakVersion                                           *string              `json:"keycloakVersion,omitempty"`
+	LoginTheme                                                *string              `json:"loginTheme,omitempty"`
+	LoginWithEmailAllowed                                     *bool                `json:"loginWithEmailAllowed,omitempty"`
+	MaxDeltaTimeSeconds                                       *int                 `json:"maxDeltaTimeSeconds,omitempty"`
+	MaxFailureWaitSeconds                                     *int                 `json:"maxFailureWaitSeconds,omitempty"`
+	MinimumQuickLoginWaitSeconds                              *int                 `json:"minimumQuickLoginWaitSeconds,omitempty"`
+	NotBefore                                                 *int                 `json:"notBefore,omitempty"`
+	OfflineSessionIdleTimeout                                 *int                 `json:"offlineSessionIdleTimeout,omitempty"`
+	OfflineSessionMaxLifespan                                 *int                 `json:"offlineSessionMaxLifespan,omitempty"`
+	OfflineSessionMaxLifespanEnabled                          *bool                `json:"offlineSessionMaxLifespanEnabled,omitempty"`
+	OtpPolicyAlgorithm                                        *string              `json:"otpPolicyAlgorithm,omitempty"`
+	OtpPolicyDigits                                           *int                 `json:"otpPolicyDigits,omitempty"`
+	OtpPolicyInitialCounter                                   *int                 `json:"otpPolicyInitialCounter,omitempty"`
+	OtpPolicyLookAheadWindow                                  *int                 `json:"otpPolicyLookAheadWindow,omitempty"`
+	OtpPolicyPeriod                                           *int                 `json:"otpPolicyPeriod,omitempty"`
+	OtpPolicyType                                             *string              `json:"otpPolicyType,omitempty"`
+	OtpSupportedApplications                                  *[]string            `json:"otpSupportedApplications,omitempty"`
+	PasswordPolicy                                            *string              `json:"passwordPolicy,omitempty"`
+	PermanentLockout                                          *bool                `json:"permanentLockout,omitempty"`
+	ProtocolMappers                                           *[]any               `json:"protocolMappers,omitempty"`
+	QuickLoginCheckMilliSeconds                               *int64               `json:"quickLoginCheckMilliSeconds,omitempty"`
+	Realm                                                     *string              `json:"realm,omitempty"`
+	RefreshTokenMaxReuse                                      *int                 `json:"refreshTokenMaxReuse,omitempty"`
+	RegistrationAllowed                                       *bool                `json:"registrationAllowed,omitempty"`
+	RegistrationEmailAsUsername                               *bool                `json:"registrationEmailAsUsername,omitempty"`
+	RegistrationFlow                                          *string              `json:"registrationFlow,omitempty"`
+	RememberMe                                                *bool                `json:"rememberMe,omitempty"`
+	RequiredActions                                           *[]any               `json:"requiredActions,omitempty"`
+	ResetCredentialsFlow                                      *string              `json:"resetCredentialsFlow,omitempty"`
+	ResetPasswordAllowed                                      *bool                `json:"resetPasswordAllowed,omitempty"`
+	RevokeRefreshToken                                        *bool                `json:"revokeRefreshToken,omitempty"`
+	Roles                                                     *RolesRepresentation `json:"roles,omitempty"`
+	ScopeMappings                                             *[]any               `json:"scopeMappings,omitempty"`
+	SMTPServer                                                *map[string]string   `json:"smtpServer,omitempty"`
+	SslRequired                                               *string              `json:"sslRequired,omitempty"`
+	SsoSessionIdleTimeout                                     *int                 `json:"ssoSessionIdleTimeout,omitempty"`
+	SsoSessionIdleTimeoutRememberMe                           *int                 `json:"ssoSessionIdleTimeoutRememberMe,omitempty"`
+	SsoSessionMaxLifespan                                     *int                 `json:"ssoSessionMaxLifespan,omitempty"`
+	SsoSessionMaxLifespanRememberMe                           *int                 `json:"ssoSessionMaxLifespanRememberMe,omitempty"`
+	SupportedLocales                                          *[]string            `json:"supportedLocales,omitempty"`
+	UserFederationMappers                                     *[]any               `json:"userFederationMappers,omitempty"`
+	UserFederationProviders                                   *[]any               `json:"userFederationProviders,omitempty"`
+	UserManagedAccessAllowed                                  *bool                `json:"userManagedAccessAllowed,omitempty"`
+	Users                                                     *[]User              `json:"users,omitempty"`
+	VerifyEmail                                               *bool                `json:"verifyEmail,omitempty"`
+	WaitIncrementSeconds                                      *int                 `json:"waitIncrementSeconds,omitempty"`
+	WebAuthnPolicyAcceptableAaguids                           *[]string            `json:"webAuthnPolicyAcceptableAaguids,omitempty"`
+	WebAuthnPolicyAttestationConveyancePreference             *string              `json:"webAuthnPolicyAttestationConveyancePreference,omitempty"`
+	WebAuthnPolicyAuthenticatorAttachment                     *string              `json:"webAuthnPolicyAuthenticatorAttachment,omitempty"`
+	WebAuthnPolicyAvoidSameAuthenticatorRegister              *bool                `json:"webAuthnPolicyAvoidSameAuthenticatorRegister,omitempty"`
+	WebAuthnPolicyCreateTimeout                               *int                 `json:"webAuthnPolicyCreateTimeout,omitempty"`
+	WebAuthnPolicyPasswordlessAcceptableAaguids               *[]string            `json:"webAuthnPolicyPasswordlessAcceptableAaguids,omitempty"`
+	WebAuthnPolicyPasswordlessAttestationConveyancePreference *string              `json:"webAuthnPolicyPasswordlessAttestationConveyancePreference,omitempty"`
+	WebAuthnPolicyPasswordlessAuthenticatorAttachment         *string              `json:"webAuthnPolicyPasswordlessAuthenticatorAttachment,omitempty"`
+	WebAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister  *bool                `json:"webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister,omitempty"`
+	WebAuthnPolicyPasswordlessCreateTimeout                   *int                 `json:"webAuthnPolicyPasswordlessCreateTimeout,omitempty"`
+	WebAuthnPolicyPasswordlessRequireResidentKey              *string              `json:"webAuthnPolicyPasswordlessRequireResidentKey,omitempty"`
+	WebAuthnPolicyPasswordlessRpEntityName                    *string              `json:"webAuthnPolicyPasswordlessRpEntityName,omitempty"`
+	WebAuthnPolicyPasswordlessRpID                            *string              `json:"webAuthnPolicyPasswordlessRpId,omitempty"`
+	WebAuthnPolicyPasswordlessSignatureAlgorithms             *[]string            `json:"webAuthnPolicyPasswordlessSignatureAlgorithms,omitempty"`
+	WebAuthnPolicyPasswordlessUserVerificationRequirement     *string              `json:"webAuthnPolicyPasswordlessUserVerificationRequirement,omitempty"`
+	WebAuthnPolicyRequireResidentKey                          *string              `json:"webAuthnPolicyRequireResidentKey,omitempty"`
+	WebAuthnPolicyRpEntityName                                *string              `json:"webAuthnPolicyRpEntityName,omitempty"`
+	WebAuthnPolicyRpID                                        *string              `json:"webAuthnPolicyRpId,omitempty"`
+	WebAuthnPolicySignatureAlgorithms                         *[]string            `json:"webAuthnPolicySignatureAlgorithms,omitempty"`
+	WebAuthnPolicyUserVerificationRequirement                 *string              `json:"webAuthnPolicyUserVerificationRequirement,omitempty"`
 }
 
 // AuthenticationFlowRepresentation represents an authentication flow of a realm
@@ -934,8 +934,7 @@ func (p *AuthorizationParameters) FormData() map[string]string {
 }
 
 // AuthorizationResponse represents the response to an authorization request.
-type AuthorizationResponse struct {
-}
+type AuthorizationResponse struct{}
 
 // TokenOptions represents the options to obtain a token
 type TokenOptions struct {
@@ -1426,6 +1425,7 @@ type RequiredActionProviderRepresentation struct {
 	ProviderID    *string            `json:"providerId,omitempty"`
 }
 
+// UnregisteredRequiredActionProviderRepresentation is a representation of unregistered required actions.
 type UnregisteredRequiredActionProviderRepresentation struct {
 	Name       *string `json:"name,omitempty"`
 	ProviderID *string `json:"providerId,omitempty"`
@@ -1446,7 +1446,7 @@ type GetClientUserSessionsParams struct {
 }
 
 // prettyStringStruct returns struct formatted into pretty string
-func prettyStringStruct(t interface{}) string {
+func prettyStringStruct(t any) string {
 	json, err := json.MarshalIndent(t, "", "\t")
 	if err != nil {
 		return ""

--- a/models.go
+++ b/models.go
@@ -581,7 +581,6 @@ type PolicyRepresentation struct {
 	Type             *string            `json:"type,omitempty"`
 	RolePolicyRepresentation
 	JSPolicyRepresentation
-	ClientPolicyRepresentation
 	TimePolicyRepresentation
 	UserPolicyRepresentation
 	AggregatedPolicyRepresentation
@@ -596,11 +595,6 @@ type RolePolicyRepresentation struct {
 // JSPolicyRepresentation represents js based policies
 type JSPolicyRepresentation struct {
 	Code *string `json:"code,omitempty"`
-}
-
-// ClientPolicyRepresentation represents client based policies
-type ClientPolicyRepresentation struct {
-	Clients *[]string `json:"clients,omitempty"`
 }
 
 // TimePolicyRepresentation represents time based policies
@@ -1493,7 +1487,6 @@ func (v *RoleDefinition) String() string                            { return pre
 func (v *PolicyRepresentation) String() string                      { return prettyStringStruct(v) }
 func (v *RolePolicyRepresentation) String() string                  { return prettyStringStruct(v) }
 func (v *JSPolicyRepresentation) String() string                    { return prettyStringStruct(v) }
-func (v *ClientPolicyRepresentation) String() string                { return prettyStringStruct(v) }
 func (v *TimePolicyRepresentation) String() string                  { return prettyStringStruct(v) }
 func (v *UserPolicyRepresentation) String() string                  { return prettyStringStruct(v) }
 func (v *AggregatedPolicyRepresentation) String() string            { return prettyStringStruct(v) }

--- a/pkg/jwx/jwx.go
+++ b/pkg/jwx/jwx.go
@@ -17,7 +17,7 @@ import (
 )
 
 // SignClaims signs the given claims using a given key and a method
-func SignClaims(claims jwt.Claims, key interface{}, method jwt.SigningMethod) (string, error) {
+func SignClaims(claims jwt.Claims, key any, method jwt.SigningMethod) (string, error) {
 	token := jwt.NewWithClaims(method, claims)
 	return token.SignedString(key)
 }
@@ -52,14 +52,12 @@ func toBigInt(v string) (*big.Int, error) {
 	return res, nil
 }
 
-var (
-	curves = map[string]elliptic.Curve{
-		"P-224": elliptic.P224(),
-		"P-256": elliptic.P256(),
-		"P-384": elliptic.P384(),
-		"P-521": elliptic.P521(),
-	}
-)
+var curves = map[string]elliptic.Curve{
+	"P-224": elliptic.P224(),
+	"P-256": elliptic.P256(),
+	"P-384": elliptic.P384(),
+	"P-521": elliptic.P521(),
+}
 
 func decodeECDSAPublicKey(x, y, crv *string) (*ecdsa.PublicKey, error) {
 	const errMessage = "could not decode public key"
@@ -123,14 +121,13 @@ func DecodeAccessTokenRSACustomClaims(accessToken string, e, n *string, customCl
 		return nil, errors.Wrap(err, errMessage)
 	}
 
-	token2, err := jwt.ParseWithClaims(accessToken, customClaims, func(token *jwt.Token) (interface{}, error) {
+	token2, err := jwt.ParseWithClaims(accessToken, customClaims, func(token *jwt.Token) (any, error) {
 		// Don't forget to validate the alg is what you expect:
 		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
 		return rsaPublicKey, nil
 	})
-
 	if err != nil {
 		return nil, errors.Wrap(err, errMessage)
 	}
@@ -147,14 +144,13 @@ func DecodeAccessTokenECDSACustomClaims(accessToken string, x, y, crv *string, c
 		return nil, errors.Wrap(err, errMessage)
 	}
 
-	token2, err := jwt.ParseWithClaims(accessToken, customClaims, func(token *jwt.Token) (interface{}, error) {
+	token2, err := jwt.ParseWithClaims(accessToken, customClaims, func(token *jwt.Token) (any, error) {
 		// Don't forget to validate the alg is what you expect:
 		if _, ok := token.Method.(*jwt.SigningMethodECDSA); !ok {
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
 		return publicKey, nil
 	})
-
 	if err != nil {
 		return nil, errors.Wrap(err, errMessage)
 	}

--- a/pkg/jwx/jwx_test.go
+++ b/pkg/jwx/jwx_test.go
@@ -8,9 +8,8 @@ import (
 	"log"
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/require"
 )
 
 var claims = jwt.MapClaims{

--- a/pkg/jwx/models.go
+++ b/pkg/jwx/models.go
@@ -34,8 +34,7 @@ type Claims struct {
 }
 
 // Address TODO what fields does any address have?
-type Address struct {
-}
+type Address struct{}
 
 // RealmAccess holds roles of the user
 type RealmAccess struct {

--- a/utils.go
+++ b/utils.go
@@ -108,13 +108,11 @@ func NilOrEmpty(value *string) bool {
 
 // NilOrEmptyArray returns true if string is empty or has a nil value
 func NilOrEmptyArray(value *[]string) bool {
-
 	if value == nil || len(*value) == 0 {
 		return true
 	}
 
 	return (*value)[0] == ""
-
 }
 
 // DecisionStrategyP returns a pointer for a DecisionStrategy value

--- a/utils_test.go
+++ b/utils_test.go
@@ -3,8 +3,9 @@ package gocloak_test
 import (
 	"testing"
 
-	"github.com/Nerzal/gocloak/v13"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/Nerzal/gocloak/v13"
 )
 
 func TestStringP(t *testing.T) {

--- a/utils_test.go
+++ b/utils_test.go
@@ -3,9 +3,8 @@ package gocloak_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/Nerzal/gocloak/v13"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestStringP(t *testing.T) {

--- a/utils_test.go
+++ b/utils_test.go
@@ -12,6 +12,7 @@ func TestStringP(t *testing.T) {
 	p := gocloak.StringP("test value")
 	assert.Equal(t, "test value", *p)
 }
+
 func TestPString(t *testing.T) {
 	p := "test value"
 	v := gocloak.PString(&p)
@@ -102,6 +103,7 @@ func TestFloat32P(t *testing.T) {
 	p := gocloak.Float32P(v)
 	assert.Equal(t, v, *p)
 }
+
 func TestFloat64P(t *testing.T) {
 	v := 42.42
 	p := gocloak.Float64P(v)
@@ -118,6 +120,7 @@ func TestPFloat32(t *testing.T) {
 	assert.Equal(t, float32(0), v)
 	assert.IsType(t, float32(0), v)
 }
+
 func TestPFloat64(t *testing.T) {
 	p := 42.42
 	v := gocloak.PFloat64(&p)
@@ -128,6 +131,7 @@ func TestPFloat64(t *testing.T) {
 	assert.Equal(t, float64(0), v)
 	assert.IsType(t, float64(0), v)
 }
+
 func TestNilOrEmptyArray(t *testing.T) {
 	a := gocloak.NilOrEmptyArray(&[]string{"c", "d"})
 	b := gocloak.NilOrEmptyArray(&[]string{"", "b"})
@@ -135,5 +139,4 @@ func TestNilOrEmptyArray(t *testing.T) {
 	assert.False(t, a)
 	assert.True(t, b)
 	assert.True(t, c)
-
 }


### PR DESCRIPTION
This PR fixes: 

- all kinds of golangci-lint warnings and errors
- compareVersions had dead code
- PolicyRepresentation unrecognized field "clients" error 👇

```
2025-02-04 12:30:16,312 ERROR [org.keycloak.services.error.KeycloakErrorHandler] (executor-thread-1) Uncaught server error: java.lang.RuntimeException: Failed to deserialize representation
	at org.keycloak.authorization.admin.PolicyService.doCreateRepresentation(PolicyService.java:135)
	at org.keycloak.authorization.admin.PolicyService.create(PolicyService.java:119)
	at org.keycloak.authorization.admin.PolicyService$quarkusrestinvoker$create_195cd61c18e9138a5e834481c705d4fd435d9cb0.invoke(Unknown Source)
	at org.jboss.resteasy.reactive.server.handlers.InvocationHandler.handle(InvocationHandler.java:29)
	at io.quarkus.resteasy.reactive.server.runtime.QuarkusResteasyReactiveRequestContext.invokeHandler(QuarkusResteasyReactiveRequestContext.java:141)
	at org.jboss.resteasy.reactive.common.core.AbstractResteasyReactiveContext.run(AbstractResteasyReactiveContext.java:147)
	at io.quarkus.vertx.core.runtime.VertxCoreRecorder$14.runWith(VertxCoreRecorder.java:582)
	at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2513)
	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1538)
	at org.jboss.threads.DelegatingRunnable.run(DelegatingRunnable.java:29)
	at org.jboss.threads.ThreadLocalResettingRunnable.run(ThreadLocalResettingRunnable.java:29)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:1583)
Caused by: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field "clients" (class org.keycloak.representations.idm.authorization.PolicyRepresentation), not marked as ignorable (13 known properties: "config", "resources", "scopesData", "name", "decisionStrategy", "policies", "owner", "type", "id", "description", "logic", "scopes", "resourcesData"])
 at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 108] (through reference chain: org.keycloak.representations.idm.authorization.PolicyRepresentation["clients"])
	at com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException.from(UnrecognizedPropertyException.java:61)
	at com.fasterxml.jackson.databind.DeserializationContext.handleUnknownProperty(DeserializationContext.java:1153)
	at com.fasterxml.jackson.databind.deser.std.StdDeserializer.handleUnknownProperty(StdDeserializer.java:2241)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.handleUnknownProperty(BeanDeserializerBase.java:1793)
	at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.handleUnknownVanilla(BeanDeserializerBase.java:1771)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:316)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:177)
	at com.fasterxml.jackson.databind.deser.DefaultDeserializationContext.readRootValue(DefaultDeserializationContext.java:342)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:4905)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3848)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:3816)
	at org.keycloak.util.JsonSerialization.readValue(JsonSerialization.java:77)
	at org.keycloak.authorization.admin.PolicyService.doCreateRepresentation(PolicyService.java:133)
	... 12 more
```

also not found in docs: https://www.keycloak.org/docs-api/latest/rest-api/index.html#PolicyRepresentation

This change probably warrants a major version upgrade as it's a breaking change in the PolicyRepresenation model