### PR TITLE
add `hideOnLogin` field to the `IdentityProviderRepresentation` struct

### DIFF
--- a/models.go
+++ b/models.go
@@ -1159,6 +1159,7 @@ type IdentityProviderRepresentation struct {
 	ProviderID                *string            `json:"providerId,omitempty"`
 	StoreToken                *bool              `json:"storeToken,omitempty"`
 	TrustEmail                *bool              `json:"trustEmail,omitempty"`
+	HideOnLogin               *bool              `json:"hideOnLogin,omitempty"`
 }
 
 // IdentityProviderMapper represents the body of a call to add a mapper to


### PR DESCRIPTION
Added an optional attribute `hideOnLogin` which exists on Identity Provider per the API documentation:
https://www.keycloak.org/docs-api/latest/rest-api/index.html#IdentityProviderRepresentation

