### PR TITLE
Add UserSessionNote field to ProtocolMappersConfig

### DIFF
--- a/models.go
+++ b/models.go
@@ -460,6 +460,7 @@ type ProtocolMappersConfig struct {
 	AttributeNameFormat                *string `json:"attribute.nameformat,omitempty"`
 	Single                             *string `json:"single,omitempty"`
 	Script                             *string `json:"script,omitempty"`
+	UserSessionNote                    *string `json:"user.session.note,omitempty"`
 }
 
 // Client is a ClientRepresentation


### PR DESCRIPTION
The ProtocolMappersConfig is missing a UserSessionNote (scope config entry user.session.note).

(See [here](https://github.com/keycloak/keycloak/blob/fa3e964df7c9c8741f889c9b8705e6c5f5c05b2a/services/src/main/java/org/keycloak/protocol/ProtocolMapperUtils.java#L46) for the relevant Keycloak source code)

This PR simply adds that field.