### PR TITLE
add fetchRoles field to RolePolicyRepresentation

### DIFF
--- a/models.go
+++ b/models.go
@@ -590,7 +590,8 @@ type PolicyRepresentation struct {
 
 // RolePolicyRepresentation represents role based policies
 type RolePolicyRepresentation struct {
-	Roles *[]RoleDefinition `json:"roles,omitempty"`
+	FetchRoles *bool             `json:"fetchRoles,omitempty"`
+	Roles      *[]RoleDefinition `json:"roles,omitempty"`
 }
 
 // JSPolicyRepresentation represents js based policies


### PR DESCRIPTION
Hey, ran into this while using the library — `fetchRoles` field is missing from `RolePolicyRepresentation`.

Found it in the Keycloak docs: https://www.keycloak.org/docs-api/latest/rest-api/index.html#RolePolicyRepresentation

Simple fix, just adding the missing field. Closes #504