### PR TITLE
fix: URL-encode client credentials in Basic Auth per RFC 6749 §2.3.1

### DIFF
--- a/client.go
+++ b/client.go
@@ -138,7 +138,7 @@ func (g *GoCloak) GetRequestWithBasicAuth(ctx context.Context, clientID, clientS
 		SetHeader("Content-Type", "application/x-www-form-urlencoded")
 	// Public client doesn't require Basic Auth
 	if len(clientID) > 0 && len(clientSecret) > 0 {
-		httpBasicAuth := base64.StdEncoding.EncodeToString([]byte(clientID + ":" + clientSecret))
+		httpBasicAuth := base64.StdEncoding.EncodeToString([]byte(url.QueryEscape(clientID) + ":" + url.QueryEscape(clientSecret)))
 		req.SetHeader("Authorization", "Basic "+httpBasicAuth)
 	}
 


### PR DESCRIPTION
## Summary

`GetRequestWithBasicAuth` builds the HTTP Basic Auth header by base64-encoding `clientID + ":" + clientSecret` directly, without URL-encoding the values first.

[RFC 6749 Section 2.3.1](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1) requires:

> The client identifier is encoded using the "application/x-www-form-urlencoded" encoding algorithm per Appendix B, and the resulting value is used as the username; the client password is encoded using the same algorithm and used as the password.

Keycloak's `BasicAuthHelper.RFC6749.parseHeader` correctly URL-decodes the Basic Auth credentials after base64-decoding, per the RFC. When a client secret contains `%` (which Keycloak can randomly generate), the unencoded `%` in the Basic Auth header causes Keycloak to throw:

```
java.lang.IllegalArgumentException: URLDecoder: Incomplete trailing escape (%) pattern
    at org.keycloak.util.BasicAuthHelper$RFC6749.parseHeader
```

This results in `invalid_client_credentials` errors on all token operations (refresh, introspect, client_credentials).

## Fix

One-line change: add `url.QueryEscape()` around both `clientID` and `clientSecret` before the base64 step. This matches Go's standard `net/http.Request.SetBasicAuth` behavior combined with the RFC 6749 §2.3.1 requirement.

Secrets containing only alphanumeric characters are unaffected since `url.QueryEscape` is identity for those strings.

## Keycloak error log (for reference)

```json
{
  "level": "ERROR",
  "message": "KC-SERVICES0015: Unexpected error when authenticating client",
  "exception": {
    "exceptionType": "java.lang.IllegalArgumentException",
    "message": "URLDecoder: Incomplete trailing escape (%) pattern",
    "frames": [
      {"class": "java.net.URLDecoder", "method": "decode"},
      {"class": "org.keycloak.util.BasicAuthHelper$RFC6749", "method": "parseHeader"},
      {"class": "org.keycloak.authentication.authenticators.client.ClientIdAndSecretAuthenticator", "method": "authenticateClient"}
    ]
  }
}
```