### PR TITLE
add revokeRefreshToken field to models

### DIFF
--- a/models.go
+++ b/models.go
@@ -824,6 +824,7 @@ type RealmRepresentation struct {
 	ProtocolMappers                                           []any                            `json:"protocolMappers,omitempty"`
 	QuickLoginCheckMilliSeconds                               *int                             `json:"quickLoginCheckMilliSeconds,omitempty"`
 	Realm                                                     *string                          `json:"realm,omitempty"`
+	RevokeRefreshToken                                        *bool                            `json:"revokeRefreshToken,omitempty"`
 	RefreshTokenMaxReuse                                      *int                             `json:"refreshTokenMaxReuse,omitempty"`
 	RegistrationAllowed                                       *bool                            `json:"registrationAllowed,omitempty"`
 	RegistrationEmailAsUsername                               *bool                            `json:"registrationEmailAsUsername,omitempty"`


### PR DESCRIPTION
The `RealmRepresentation` struct was missing the `revokeRefreshToken` field. This PR simply adds that field.